### PR TITLE
[zuul] Use alternative syntax for defining hooks (#102)

### DIFF
--- a/ci/vars-functional-test.yml
+++ b/ci/vars-functional-test.yml
@@ -1,7 +1,6 @@
 ---
 # temp: skip os-net-setup
 cifmw_os_net_setup_config: []
-post_deploy:
-  - name: run functional test
-    source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/run_playbooks.yml"
-    type: playbook
+post_deploy_run_functional_test:
+  source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/run_playbooks.yml"
+  type: playbook


### PR DESCRIPTION
ci-framework allows for hooks to be defined as multiple hooks in a list, or single hooks in their own parameters.
If two separate vars files (passed to cifmw_extras) define the same hook, then one gets overwritten by the other, depending on the order in which the vars files are imported.

Using the "single hook in its own parameter" method of defining the hook prevents this issue.