### PR TITLE
[WIP] Add  jUNitXML plugin to create the output xml file

### DIFF
--- a/ci/ansible.cfg
+++ b/ci/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
-callbacks_enabled = custom_logger
+callbacks_enabled = custom_logger, junit
 callback_plugins = ../callback_plugins
 # additional paths to search for roles
 roles_path = ../roles:/usr/share/ansible/roles:/etc/ansible/roles:~/.ansible/roles:../../ci-framework/roles

--- a/ci/osp18_functional_tests.yml
+++ b/ci/osp18_functional_tests.yml
@@ -5,6 +5,7 @@
   environment:
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
     PATH: "{{ cifmw_path }}"
+    JUNIT_TEST_CASE_PREFIX: "testsuites"
   tasks:
     - name: "Run Telemetry Autoscaling tests"
       ansible.builtin.import_role:

--- a/ci/report_result.yml
+++ b/ci/report_result.yml
@@ -4,6 +4,7 @@
     cmd: |
       cp  {{ fvt_dir }}/test_run_result.out {{ logs_dir }}/test_run_result.log
       cp  {{ fvt_dir }}/summary_results.log {{ logs_dir }}/summary_results.log
+      cp  ~/.ansible.log/*.xml {{ logs_dir }}/junittest_run_result.xml
 
 - name: Grep the number of failed tasks
   ansible.builtin.shell:


### PR DESCRIPTION
Going forward polarion supports only xml reporting. Hence testing jUNitXML plugin in ansible to o/p logs into xml format

OSPRH-8374