### PR TITLE
[telemetry_logging] Update the journal tests

### DIFF
--- a/roles/telemetry_logging/tasks/journal_tests.yml
+++ b/roles/telemetry_logging/tasks/journal_tests.yml
@@ -1,10 +1,15 @@
 ---
-- name: Get journals
+- name: |
+    Get journals {{ item }}
+    {{ journal_test_id }}
+  become: true
   ansible.builtin.shell:
-    cmd:
+    cmd: |
       tstamp=$(date -d '30 minute ago' "+%Y-%m-%d %H:%M:%S")
-      journalctl -t "{{ item }}" --no-pager -S "${tstamp}" | wc -l
+      journalctl -t "{{ item }}" --no-pager -S "${tstamp}"
   register: journal_wc
   changed_when: false
   failed_when:  
-    - journal_wc.stdout | int <= 1
+    - journal_wc.stdout_lines | length <= 1
+    - '"-- No entries --" in journal_wc.stdout'
+    - journal_wc.stderr_lines | length > 0

--- a/roles/telemetry_logging/tasks/main.yml
+++ b/roles/telemetry_logging/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Verify journal entries - {{ journal_test_id }}"
+- name: "Verify journal entries"
   when: journal_list is defined
   ansible.builtin.include_tasks: "journal_tests.yml"
-  loop: "{{ identifiers_list }}"
+  loop: "{{ journal_list }}"


### PR DESCRIPTION
* Update var names: identifiers_list -> journal_list
* Replace "| wc" in shell with check for stdout_lines | length in failure conditions
* Add additional failure conditions
    * if there are no journal entries, the rc is 0 and the number of lines 1 ("-- No entries --")
    * there should be nothing output to stderr
* fix syntax error on multi-line command (add |)
* use "become: true", to give the task the escalated priviledges it needs to access the journal
* rename the task to include the test ID, so that the custom_logger plugin logs the test result