### PR TITLE
[report_result] Update check for failed tests

### DIFF
--- a/ci/report_result.yml
+++ b/ci/report_result.yml
@@ -44,9 +44,17 @@
         cmd: |
           grep "failed" {{ logs_dir }}/test_run_result.out
       register: tasks_failed
+      # The RC from grep is 1 when there is no string matched (i.e. when there are no failures)
       ignore_errors: yes
 
+      # The RC from grep is 0 if the string is matched
     - name: Determine success or failure based on the number of failed tasks
       ansible.builtin.fail:
         msg: "The log file(s) contain failed task."
-      when: tasks_failed.stdout_lines | length > 0
+      when: tasks_failed.stdout_lines | length > 0 and tasks_failed.rc == 0
+
+      # The RC from grep is 2 if an error occurred.
+    - name: Fail if the file was not found (or other grep error)
+      ansible.builtin.fail:
+        msg: "{{ tasks_failed.stderr if tasks_failed.stderr | length > 0 else 'There was an error with grep.' }}"
+      when: tasks_failed.rc > 1


### PR DESCRIPTION
grep fails when there are no lines matched (rc=1), but also when the file doesn't exist (rc>1). This change updates the check so that the error is reported properly.