### PR TITLE
[custom_logger] Make the output dir configurable

### DIFF
--- a/callback_plugins/custom_logger.py
+++ b/callback_plugins/custom_logger.py
@@ -17,6 +17,16 @@ DOCUMENTATION = '''
     - Log file names:
         - test_run_result.out
         - summary_results.log
+    options:
+        output_dir:
+            description: todo
+            ini:
+              - section: custom_logger
+                key: output_dir
+            env:
+              - name: CUSTOM_LOGGER_OUTPUT_DIR
+            default: "."
+            type: path
 '''
 
 class CallbackModule(CallbackBase):
@@ -31,9 +41,11 @@ class CallbackModule(CallbackBase):
 
     def __init__(self):
         super(CallbackModule, self).__init__()
-        self.output_dir =  os.path.expanduser("~/")
-        self.results = {}
+        self.set_options()
         
+        self.output_dir = self.get_option('output_dir')
+        self.results = {}
+
     def playbook_on_stats(self, stats):
         #Log results for each host
         hosts= stats.processed

--- a/ci/ansible.cfg
+++ b/ci/ansible.cfg
@@ -3,3 +3,6 @@ callbacks_enabled = custom_logger
 callback_plugins = ../callback_plugins
 # additional paths to search for roles
 roles_path = ../roles:/usr/share/ansible/roles:/etc/ansible/roles:~/.ansible/roles:../../ci-framework/roles
+
+[custom_logger]
+output_dir = /$HOME


### PR DESCRIPTION
Allow configuration via the env var CUSTOM_PLUGIN_OUTPUT_DIR or the ini file using the "output_dir" option in the "custom_logger" section.

NOTE: For paths, a leading "/" is needed when using env vars so that the path is read as an absolute path.