### PR TITLE
The observability strategy role should not be run in stf_funtional_tests

### DIFF
--- a/stf_functional_tests.yml
+++ b/stf_functional_tests.yml
@@ -65,9 +65,6 @@
       ansible.builtin.import_role:
         name: test_verify_email
 
-    - name: "Test observabilityStrategy"
-      ansible.builtin.import_role:
-        name: test_observability_strategy
   tags:
     - custom-stf-ceph
     - stf-connectors-osp13-ffu


### PR DESCRIPTION
The observability strategy role should not be run in stf_funtional_tests

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1115