### PR TITLE
Switch to server_group for 18 autoscaling

### DIFF
--- a/ci/patch-openstack-versions.yaml
+++ b/ci/patch-openstack-versions.yaml
@@ -4,6 +4,8 @@ spec:
     aodhEvaluatorImage: quay.io/podified-master-centos9/openstack-aodh-evaluator:current-podified
     aodhListenerImage: quay.io/podified-master-centos9/openstack-aodh-listener:current-podified
     aodhNotifierImage: quay.io/podified-master-centos9/openstack-aodh-notifier:current-podified
+    ceilometerCentralImage: quay.io/podified-master-centos9/openstack-ceilometer-central:current-podified
+    ceilometerComputeImage: quay.io/podified-master-centos9/openstack-ceilometer-compute:current-podified
     heatAPIImage: quay.io/podified-master-centos9/openstack-heat-api:current-podified
     heatCfnapiImage: quay.io/podified-master-centos9/openstack-heat-api-cfn:current-podified
     heatEngineImage: quay.io/podified-master-centos9/openstack-heat-engine:current-podified

--- a/ci/run_autoscaling_osp18.yml
+++ b/ci/run_autoscaling_osp18.yml
@@ -29,6 +29,17 @@
           tags:
             - setup
 
+        - name: Redeploy the dataplane
+          ansible.builtin.shell:
+            cmd: |
+              oc get osdpd edpm-deployment -oyaml > /tmp/osdpd.yaml
+              oc delete osdpd edpm-deployment
+              sleep 10
+              oc apply -f /tmp/osdpd.yaml
+          when: "{{ patch_openstackversions | bool }}"
+          tags:
+            - setup
+
         - name: Patch observabilityclient into openstackclient
           ansible.builtin.shell:
             cmd: |
@@ -51,6 +62,18 @@
           tags:
             - setup
 
+        - name: Wait until the osdpd is redeployed to continue
+          ansible.builtin.shell:
+            cmd: |
+              oc get osdpd | grep "Setup complete"
+          retries: 60
+          delay: 45
+          until: output.stdout_lines | length == 1
+          register: output
+          when: "{{ patch_openstackversions | bool }}"
+          tags:
+            - setup
+
         - name: "Run Telemetry Autoscaling tests"
           ansible.builtin.import_role:
             name: telemetry_autoscaling
@@ -61,4 +84,15 @@
             cmd: |
               oc patch  openstackversions controlplane  --type json -p='[{"op": "replace", "path": "/spec/customContainerImages", "value": {} }]'
           when: "{{ patch_openstackversions | bool }}"
+
+        - name: Redeploy the dataplane
+          ansible.builtin.shell:
+            cmd: |
+              oc get osdpd edpm-deployment -oyaml > /tmp/osdpd.yaml
+              oc delete osdpd edpm-deployment
+              sleep 10
+              oc apply -f /tmp/osdpd.yaml
+          when: "{{ patch_openstackversions | bool }}"
+          tags:
+            - setup
 

--- a/roles/telemetry_autoscaling/tasks/creating_stack.yml
+++ b/roles/telemetry_autoscaling/tasks/creating_stack.yml
@@ -63,7 +63,7 @@
     # source ~/overcloudrc;
     {{ openstack_cmd }} metric list
   register: result
-  failed_when: result.rc >= 1
+  failed_when: '"ceilometer_cpu" not in result.stdout'
 
 - name: Print the result
   ansible.builtin.debug:
@@ -82,7 +82,7 @@
     # source ~/overcloudrc;
     {{ openstack_cmd }} alarm list
   register: result
-  failed_when: result.rc >= 1
+  failed_when: '"cpu_alarm_high" not in result.stdout or "cpu_alarm_low" not in result.stdout'
 
 - name: Note the physical_resource_id values for the cpu_alarm_low resource
   ansible.builtin.shell: |
@@ -101,7 +101,7 @@
 - name: RHOSO-12653 Verify physical_resource_id match the alarm id for cpu_alarm_low
   ansible.builtin.shell: |
     # source ~/overcloudrc;
-    {{ openstack_cmd }} alarm list |grep -i cpu_alarm_low | awk '{print $2}'
+    {{ openstack_cmd }} alarm list |grep -i cpu_alarm_low | grep {{ stack_name }} | awk '{print $2}'
   register: alarm_id_low
   failed_when:
     - physical_resource_id_low.stdout != alarm_id_low.stdout
@@ -109,12 +109,11 @@
 - name: RHOSO-12654 Verify physical_resource_id match the alarm id for cpu_alarm_high
   ansible.builtin.shell: |
     # source ~/overcloudrc;
-    {{ openstack_cmd }} alarm list |grep -i cpu_alarm_high | awk '{print $2}'
+    {{ openstack_cmd }} alarm list |grep -i cpu_alarm_high | grep {{ stack_name }} | awk '{print $2}'
   register: alarm_id_high
   failed_when:
     - physical_resource_id_high.stdout != alarm_id_high.stdout
 
-  # TODO: get alt check for prom
 - name: Verify that metric resources exist for the stack
   when: metrics_backend == "gnocchi"
   ansible.builtin.shell: |
@@ -125,5 +124,17 @@
     -c display_name -c launched_at \
     -c deleted_at --type instance \
     server_group="$STACK_ID"
+  register: result
+  failed_when: result.rc >= 1
+
+# NOTE(jwysogla) we query a specific metric instead of existence of server_group='$STACK_ID' in general
+# which is a little different from the task above. We could also curl the Prometheus API directly to check
+# if there is a label with some value like this: "curl <prometheus>/api/v1/label/server_group/values | grep $STACK_ID"
+# but this isn't possible with the "openstack metric" command (at least not right now).
+- name: Verify that metric resources exist for the stack
+  when: metrics_backend == "prometheus"
+  ansible.builtin.shell: |
+    export STACK_ID=$({{ openstack_cmd }} stack show {{ stack_name }} -c id -f value);
+    {{ openstack_cmd }} metric query "ceilometer_cpu{server_group='$STACK_ID'}"
   register: result
   failed_when: result.rc >= 1

--- a/roles/telemetry_autoscaling/tasks/post_teardown.yml
+++ b/roles/telemetry_autoscaling/tasks/post_teardown.yml
@@ -14,10 +14,9 @@
 
 - name: Wait until the stack is deleted
   ansible.builtin.shell:
-    cmd: oc rsh openstackclient openstack stack list | grep {{ stack_name }}
+    cmd: oc rsh openstackclient openstack stack list | grep {{ stack_name }} | wc -l
   register: output
-  until: output.stdout_lines == 0
+  until: output.stdout == '0'
   ignore_errors: true
   retries: 50
   timeout: 5
-

--- a/roles/telemetry_autoscaling/tasks/test_autoscaling.yml
+++ b/roles/telemetry_autoscaling/tasks/test_autoscaling.yml
@@ -62,6 +62,7 @@
     # source ~/overcloudrc;
     {{ openstack_cmd }} alarm list -c state -c name -f value| \
         grep -i "cpu_alarm_high" | \
+        grep -i "{{ stack_name }}" | \
         awk '{print $2}'
   retries: 100
   delay: 5
@@ -92,20 +93,18 @@
     # source ~/overcloudrc;
     {{ openstack_cmd }} alarm list -c state -c name -f value| \
         grep -i "cpu_alarm_low" | \
+        grep -i "{{ stack_name }}" | \
         awk '{print $2}'
   retries: 100
   delay: 5
   register: result
   until: result.stdout == "alarm"
 
-  # TODO: the metering.server group metadata was used for gnocchi alarm
-  # selection.
-  # prom uses the instance name, so the metadata MIGHT be removed, and a new
-  # check for whether the scaling group has scaled down may be needed.
 - name: RHOSO-12663 Verify that the Orchestration service has scaled down the instances
   ansible.builtin.shell: |
     # source ~/overcloudrc;
-    {{ openstack_cmd }} server list --long|grep -i metering.server_group |wc -l
+    export STACK_ID=$({{ openstack_cmd }} stack show {{ stack_name }} -c id -f value)
+    {{ openstack_cmd }} server list --long|grep -i metering.server_group=\'$STACK_ID\' |wc -l
   retries: 100
   delay: 5
   register: instance_count3

--- a/roles/telemetry_autoscaling/templates/instance.yaml.j2
+++ b/roles/telemetry_autoscaling/templates/instance.yaml.j2
@@ -24,10 +24,6 @@ parameters:
     type: string
     description: network used for floating IPs
     default: {{ stack_external_network | default("public") }}
-  server_name_prefix:
-    type: string
-    description: a prefix for each server name.
-    default: ""
   security_group:
     type: string
     description: the security group for the instances
@@ -37,10 +33,6 @@ resources:
   vnf:
     type: OS::Nova::Server
     properties:
-      {% if metrics_backend == "prometheus" -%}
-      name:
-        list_join: ["", [{get_param: server_name_prefix}, {get_param: OS::stack_name}]]
-      {% endif -%}
       flavor: {get_param: flavor}
       #key_name: {get_param: key_name}
       image: { get_param: image }

--- a/roles/telemetry_autoscaling/templates/template.yaml.j2
+++ b/roles/telemetry_autoscaling/templates/template.yaml.j2
@@ -1,11 +1,5 @@
 heat_template_version: wallaby
 description:  Example auto scale group, policy and alarm
-parameters:
-  server_name_prefix:
-    description: A prefix for servers created by this stack. Can be used in queries.
-    type: string
-    default: autoscaling_server_
-
 resources:
   scaleup_group:
     type: OS::Heat::AutoScalingGroup
@@ -16,7 +10,6 @@ resources:
       resource:
         type: OS::Nova::Server::VNF
         properties:
-          server_name_prefix: { get_param: server_name_prefix }
           metadata: {"metering.server_group": {get_param: "OS::stack_id"}}
 
 
@@ -70,9 +63,9 @@ resources:
         {% endif -%}
         {% if metrics_backend == "prometheus" -%}
         str_replace:
-          template: "(rate(ceilometer_cpu{resource_name=~'server_name_prefix.*'}[150s]))/10000000"
+          template: "(rate(ceilometer_cpu{server_group=~'stack_id'}[150s]))/10000000"
           params:
-            server_name_prefix: {get_param: server_name_prefix}
+            stack_id: {get_param: OS::stack_id}
         {%- endif %}
 
   cpu_alarm_low:
@@ -107,9 +100,9 @@ resources:
         {% endif -%}
         {% if metrics_backend == "prometheus" -%}
         str_replace:
-          template: "(rate(ceilometer_cpu{resource_name=~'server_name_prefix.*'}[150s]))/10000000"
+          template: "(rate(ceilometer_cpu{server_group=~'stack_id'}[150s]))/10000000"
           params:
-            server_name_prefix: {get_param: server_name_prefix}
+            stack_id: {get_param: OS::stack_id}
         {% endif %}
 
 outputs:


### PR DESCRIPTION
Latest updates to ceilometer and sg-core allow us to use server_group for autoscaling server grouping instead of the server_name_prefix. Unfortunately this functionality is only on ceilometer master, so we need to patch the openstackversions to use that. Because ceilometer-central-agent is running on the compute nodes, we need to redeploy the dataplane after patching the openstackversions.

I also found a few TODOs and other places that I thought I can enhance a little. I included that as well.