### PR TITLE
Enable NodeExporter tests in metric-verification

### DIFF
--- a/roles/telemetry_verify_metrics/defaults/main.yml
+++ b/roles/telemetry_verify_metrics/defaults/main.yml
@@ -2,6 +2,5 @@
 telemetry_verify_metrics_metric_sources_to_test:
   - ceilometer_compute_agent
   - ceilometer_central_agent
-# Disable node exporter testing until OSPRH-11059 is fixed
-#  - node_exporter
+  - node_exporter
   - rabbitmq


### PR DESCRIPTION
I think the bug should be fixed now.