### PR TITLE
Determine API versions based on observability strategy

### DIFF
--- a/roles/test_alerts/tasks/get_observability_api.yml
+++ b/roles/test_alerts/tasks/get_observability_api.yml
@@ -1,0 +1,12 @@
+---
+- name: "Get the observability strategy"
+  ansible.builtin.shell:
+    cmd: |
+      oc get stf default -ojsonpath='{.spec.observabilityStrategy}'
+  changed_when: false
+  register: observability_strategy
+
+- name: "Set the observability api based on the observability strategy"
+  ansible.builtin.set_fact:
+    observability_api: "{{ 'monitoring.rhobs' if observability_strategy.stdout == 'use_redhat' else 'monitoring.coreos.com' }}"
+

--- a/roles/test_alerts/tasks/main.yml
+++ b/roles/test_alerts/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: "Get the observability strategy and set the observability_api"
+  ansible.builtin.include_tasks:
+    file: get_observability_api.yml
+
 - name: "Test Creating an alert rule in Prometheus"
   ansible.builtin.include_tasks:
     file: test_create_an_alert.yml

--- a/roles/test_alerts/tasks/test_create_an_alert.yml
+++ b/roles/test_alerts/tasks/test_create_an_alert.yml
@@ -8,7 +8,7 @@
   ansible.builtin.shell:
     cmd: |
       oc apply -f - <<EOF
-      apiVersion: monitoring.coreos.com/v1
+      apiVersion: {{ observability_api }}/v1
       kind: PrometheusRule
       metadata:
         creationTimestamp: null

--- a/roles/test_verify_email/tasks/main.yml
+++ b/roles/test_verify_email/tasks/main.yml
@@ -1,12 +1,17 @@
 ---
 # tasks file for roles/test_verify_email
 
+- name: "Get the observability strategy and set observability_api"
+  ansible.builtin.include_role:
+    name: test_alerts
+    tasks_from: get_observability_api.yml
+
 - name: "RHELOSP-176042"
   # "Create the alert"
   ansible.builtin.shell:
     cmd: |
       oc apply -f - <<EOF
-      apiVersion: monitoring.coreos.com/v1
+      apiVersion: {{ observability_api }}/v1
       kind: PrometheusRule
       metadata:
         creationTimestamp: null


### PR DESCRIPTION
Depending on the observability strategy that STF uses, observability components will be installed from community or Red hat sources. These crate the same CRDs, but with different APIs e.g.
prometheusrules.monitoring.rhobs vs
prometheusrules.monitoring.coreos.com. An apiVersion needs to be set when creating these resources during the tests, and the tests will fail if the correct version is not available.

The test_alerts role will select which observability APIs to use based on which observability_straegy is set. The tests will also explicitly use the fully qualified name of the objects using ``oc get``.

The following roles are updated:
* test_alerts
* test_verify_email

Depends-On: https://github.com/infrawatch/feature-verification-tests/pull/177