### PR TITLE
Rename tasks to have test id and description

### DIFF
--- a/roles/client_side_tests/tasks/test_e2e.yml
+++ b/roles/client_side_tests/tasks/test_e2e.yml
@@ -3,8 +3,7 @@
   ansible.builtin.include_tasks:
     file: get_prom_info.yml
 
-- name: RHELOSP-37759
-#     Description: Query Prometheus for collectd_cpu_percent metrics and save the output into the file
+- name: RHELOSP-37759 Query Prometheus for collectd_cpu_percent metrics and save the output into the file
   ansible.builtin.shell:
     cmd: >-
       /usr/bin/curl -k {{ prom_auth_string }} \
@@ -16,8 +15,7 @@
   failed_when:
     - checkmyconf.rc !=0
 
-- name: RHELOSP-57528
-#     Description: Query Prometheus for ceph_ceph_bytes metrics and save the output into the file
+- name: RHELOSP-57528 Query Prometheus for ceph_ceph_bytes metrics and save the output into the file
   ansible.builtin.shell:
     cmd: >-
       /usr/bin/curl -k {{ prom_auth_string }} \
@@ -29,8 +27,7 @@
   failed_when:
     - checkmyconf.rc !=0
 
-- name: RHELOSP-57536
-#     Description: Query Prometheus for collectd_interface_if_packets_tx_total metrics and save the output into the file
+- name: RHELOSP-57536 Query Prometheus for collectd_interface_if_packets_tx_total metrics and save the output into the file
   ansible.builtin.shell:
     cmd: >-
       /usr/bin/curl -k {{ prom_auth_string }} \
@@ -42,8 +39,7 @@
   failed_when:
     - checkmyconf.rc !=0
 
-- name: RHELOSP-37762
-#     Description: Query Prometheus for collectd_memory metrics and save the output into the file
+- name: RHELOSP-37762 Query Prometheus for collectd_memory metrics and save the output into the file
   ansible.builtin.shell:
     cmd: >-
       /usr/bin/curl -k {{ prom_auth_string }} \
@@ -55,8 +51,7 @@
   failed_when:
     - checkmyconf.rc !=0
 
-- name: RHELOSP-117539
-#     Description: Query Prometheus for collectd_load_longterm metrics and save the output into the file
+- name: RHELOSP-117539 Query Prometheus for collectd_load_longterm metrics and save the output into the file
   ansible.builtin.shell:
     cmd: >-
       /usr/bin/curl -k {{ prom_auth_string }} \
@@ -68,8 +63,7 @@
   failed_when:
     - checkmyconf.rc !=0
 
-- name: RHELOSP-37757
-#     Description: Read content of query_ceph_ceph_bytes file and check that metrics are present
+- name: RHELOSP-37757 Read content of query_ceph_ceph_bytes file and check that metrics are present
   ansible.builtin.command:
     cmd: >-
        egrep 'ceph' /tmp/query_ceph_ceph_bytes
@@ -78,8 +72,7 @@
   failed_when:
     - checkmyconf.rc != 0
 
-- name: RHELOSP-37218
-#     Description: Read content of query_collectd_interface_tx_total file and check that metrics are present
+- name: RHELOSP-37218 Read content of query_collectd_interface_tx_total file and check that metrics are present
   ansible.builtin.shell:
     cmd: >-
        egrep 'controller-0|controller-1|controller-2|compute-0|compute-1|ceph-0' /tmp/query_collectd_interface_tx_total
@@ -88,8 +81,7 @@
   failed_when:
     - checkmyconf.rc != 0
 
-- name: RHELOSP-37636
-#     Description: Read contents of query_collectd_cpu_percent file and check that metrics are present
+- name: RHELOSP-37636 Read contents of query_collectd_cpu_percent file and check that metrics are present
   ansible.builtin.shell:
     cmd: >-
       egrep 'controller-0|controller-1|controller-2|compute-0|compute-1|ceph-0' /tmp/query_collectd_cpu_percent
@@ -99,8 +91,7 @@
     - checkmyconf.rc != 0
 
 
-- name: RHELOSP-37670
-#     Description: Read content of query_collectd_memory file and check that metrics are present
+- name: RHELOSP-37670 Read content of query_collectd_memory file and check that metrics are present
   ansible.builtin.shell:
     cmd: >-
       egrep 'controller-0|controller-1|controller-2|compute-0|compute-1|ceph-0' /tmp/query_collectd_memory
@@ -110,8 +101,7 @@
     - checkmyconf.rc != 0
 
 
-- name: RHELOSP-37224
-#     Description: Read contents of query_load_longterm file and check that metrics are present
+- name: RHELOSP-37224 Read contents of query_load_longterm file and check that metrics are present
   ansible.builtin.shell:
     cmd: >-
       egrep 'controller-0|controller-1|controller-2|compute-0|compute-1|ceph-0' /tmp/query_load_longterm

--- a/roles/test_alerts/tasks/test_create_an_alert.yml
+++ b/roles/test_alerts/tasks/test_create_an_alert.yml
@@ -3,8 +3,7 @@
 # Assuming we're in the right project already...
 # Following procedure on https://infrawatch.github.io/documentation/#creating-an-alert-rule-in-prometheus_assembly-advanced-features
 
-- name: "RHELOSP-144965"
-# description: Create the alert
+- name: "RHELOSP-144965 Create the alert"
   ansible.builtin.shell:
     cmd: |
       oc apply -f - <<EOF
@@ -28,8 +27,7 @@
   register: cmd_output
   failed_when: cmd_output.rc != 0
 
-- name: "RHELOSP-144480"
-# description: Check that the alert was created
+- name: "RHELOSP-144480 Check that the alert was created"
   ansible.builtin.command:
     cmd: |
       curl -k {{ prom_auth_string }} https://{{ prom_url }}/api/v1/rules

--- a/roles/test_alerts/tasks/test_creating_a_standard_alert_route_in_alert_manager.yml
+++ b/roles/test_alerts/tasks/test_creating_a_standard_alert_route_in_alert_manager.yml
@@ -3,8 +3,7 @@
 
 # Pre-check: is the value of global.timeout = 5m in the alertmanager secret
   # TODO: put the patch into a file. and use --patch-file instead of -p OR slurp the file from files/
-- name: "RHELOSP-144965"
-# description: "Patch the ServiceTelemetry object for the STF deployment"
+- name: "RHELOSP-144965 Patch the ServiceTelemetry object for the STF deployment"
   ansible.builtin.shell:
     cmd: |
       oc patch stf default --type merge -p '{"spec": {"alertmanagerConfigManifest": "apiVersion: v1\nkind: Secret\nmetadata:\n  name: 'alertmanager-default'\n  namespace: 'service-telemetry'\ntype: Opaque\nstringData:\n  alertmanager.yaml: |-\n    global:\n      resolve_timeout: 10m\n    route:\n      group_by: ['job']\n      group_wait: 30s\n      group_interval: 5m\n      repeat_interval: 12h\n      receiver: 'null'\n    receivers:\n    - name: 'null'\n"}}'
@@ -34,16 +33,14 @@
   ansible.builtin.debug:
     var: alertmanager_secret
 
-- name: "RHELOSP-148697"
-# description: Interrupt metrics flow by preventing the QDR from running
+- name: "RHELOSP-148697 Interrupt metrics flow by preventing the QDR from running"
   ansible.builtin.shell:
     cmd: |
       for i in {1..15}; do oc delete po -l application=default-interconnect; sleep 1; done
   changed_when: false
 
 
-- name: "RHELOSP-148698"
-# description: Verify that the alert is active in Alertmanager
+- name: "RHELOSP-148698 Verify that the alert is active in Alertmanager"
   ansible.builtin.shell: 
     cmd: >-
       oc exec -it prometheus-default-0 -c prometheus -- /bin/sh -c 'wget --header \
@@ -53,8 +50,7 @@
   changed_when: false
   failed_when: cmd_output.stdout|int == 0
 
-- name: "RHELOSP-148699"
-# description: "Verify that the alert is firing in Prometheus"
+- name: "RHELOSP-148699 Verify that the alert is firing in Prometheus"
   ansible.builtin.shell:
     cmd: >-
       /usr/bin/curl -k {{ prom_auth_string }} -g https://{{ prom_url }}/api/v1/alerts | grep 'firing' | grep 'Collectd metrics receive rate is zero' | wc -l
@@ -68,8 +64,7 @@
     minutes: 2
 
 
-- name: "RHELOSP-176039"
-  # Remove alertmanagerConfigManifest from the ServiceTelemetry object
+- name: "RHELOSP-176039 Remove alertmanagerConfigManifest from the ServiceTelemetry object"
   ansible.builtin.shell:
     cmd: |
       oc patch stf/default --type='json' -p '[{"op": "remove", "path": "/spec/alertmanagerConfigManifest"}]'

--- a/roles/test_collectd/tasks/main.yml
+++ b/roles/test_collectd/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
-- name: RHELOSP-60406
-#     Description: Check whether collectd container is running
+- name: RHELOSP-60406 Check whether collectd container is running
   ansible.builtin.shell: |
     set -o pipefail
     {{ container_bin }} ps | grep {{ collectd_container_name }}
@@ -8,8 +7,7 @@
   changed_when: false
   failed_when: container_nodes.stdout_lines|length != 1
 
-- name: RHELOSP-60411
-#     Description: Check for a non-zero number of metrics from collectd
+- name: RHELOSP-60411 Check for a non-zero number of metrics from collectd
   ansible.builtin.command: |
     {{ container_bin }} exec {{ collectd_container_name }} collectdctl -s /var/run/collectd-socket listval
   register: metrics
@@ -24,8 +22,7 @@
   ansible.builtin.debug:
     var: metrics.stdout_lines[-20]
 
-- name: RHELOSP-69331
-#     Description: Get the value of some metric from collectd
+- name: RHELOSP-69331 Get the value of some metric from collectd
   ansible.builtin.command: |
     {{ container_bin }} exec {{ collectd_container_name }} collectdctl -s /var/run/collectd-socket getval {{ metrics.stdout_lines[-20] }}
   register: stat

--- a/roles/test_metrics_retention/tasks/main.yml
+++ b/roles/test_metrics_retention/tasks/main.yml
@@ -4,8 +4,7 @@
 # Assuming we're in the right project already...
 
 
-- name: "RHELOSP-144988"
-# description: "Set metrics retention to 17d"
+- name: "RHELOSP-144988 Set metrics retention to 17d"
   ansible.builtin.shell:
     cmd: |
       oc patch stf/default --type merge -p '{"spec": {"backends": {"metrics": {"prometheus": {"enabled": true, "scrapeInterval": "10s", "storage": {"retention": "17d", "strategy": "ephemeral"}}}}}}'
@@ -20,8 +19,7 @@
   changed_when: false
 
 
-- name: "RHELOSP-144484"
-# description: "Check that the retention was set"
+- name: "RHELOSP-144484 Check that the retention was set"
   ansible.builtin.shell:
     cmd: |
       oc describe pod prometheus-default-0  | grep -o 'storage.tsdb.retention.time=17d' | wc -l

--- a/roles/test_observability_strategy/tasks/main.yml
+++ b/roles/test_observability_strategy/tasks/main.yml
@@ -3,8 +3,7 @@
 # Following procedure on https://infrawatch.github.io/documentation/#configuring-observability-strategy_assembly-installing-the-core-components-of-stf
 # Assuming we're in teh right project already...
 
-- name: "RHELOSP-148696"
-# description: "Add observabilityStrategy to the STF object"
+- name: "RHELOSP-148696 Add observabilityStrategy to the STF object"
   ansible.builtin.shell:
     cmd: |
       oc patch stf/default --type merge -p '{"spec":{"observabilityStrategy": "none"}}'
@@ -12,8 +11,7 @@
   register: cmd_output
   failed_when: cmd_output.rc != 0
 
-- name: "RHELOSP-148700"
-# description: delete Grafana object
+- name: "RHELOSP-148700 delete Grafana object"
   ansible.builtin.shell:
     cmd: |
       oc delete grafana default && while oc get po -l app=grafana | grep grafana; do sleep 1; done;
@@ -21,8 +19,7 @@
   register: cmd_output
   failed_when: cmd_output.rc != 0
 
-- name: "RHELOSP-148701"
-# description: "Delete Prometheus object"
+- name: "RHELOSP-148701 Delete Prometheus object"
   ansible.builtin.shell:
     cmd: |
       oc delete prometheus default && while oc get po -l app=prometheus | grep prometheus; do sleep 1; done;
@@ -30,8 +27,7 @@
   register: cmd_output
   failed_when: cmd_output.rc != 0
 
-- name: "RHELOSP-148702"
-# description: "Delete Alertmanager object"
+- name: "RHELOSP-148702 Delete Alertmanager object"
   ansible.builtin.shell:
     cmd: |
       oc delete alertmanager default && while oc get po -l app=alertmanager | grep alertmanager; do sleep 1; done;
@@ -39,8 +35,7 @@
   register: cmd_output
   failed_when: cmd_output.rc != 0
 
-- name: "RHELOSP-148703"
-# desription: "Delete ElasticSearch  object"
+- name: "RHELOSP-148703 Delete ElasticSearch  object"
   ansible.builtin.shell:
     cmd: |
       oc delete elasticsearches.elasticsearch.k8s.elastic.co elasticsearch &&  while oc get po | grep elasticsearch; do sleep 1; done;
@@ -52,8 +47,7 @@
   ansible.builtin.pause:
     minutes: 2
 
-- name: "RHELOSP-148704"
-# description: "Verify that there no events SG pods"
+- name: "RHELOSP-148704 Verify that there no events SG pods"
   ansible.builtin.shell:
     cmd: |
       oc get pods | grep event| wc -l
@@ -61,8 +55,7 @@
   failed_when: "cmd_output.stdout|int !=0"
   changed_when: false
 
-- name: "RHELOSP-148705"
-# description: "Verify that Grafana pod didn't respawn"
+- name: "RHELOSP-148705 Verify that Grafana pod didn't respawn"
   ansible.builtin.shell:
     cmd: |
       oc get pods | grep grafana-deployment | wc -l
@@ -70,8 +63,7 @@
   failed_when: "cmd_output.stdout|int !=0"
   changed_when: false
 
-- name: "RHELOSP-148706"
-# description: "Verify that Prometheus pod didn't respawn"
+- name: "RHELOSP-148706 Verify that Prometheus pod didn't respawn"
   ansible.builtin.shell:
     cmd: |
       oc get pods | grep prometheus-default | wc -l
@@ -79,8 +71,7 @@
   failed_when: "cmd_output.stdout|int !=0"
   changed_when: false
 
-- name: "RHELOSP-148708"
-# description: "Verify that Alertmanager pod didn't respawn"
+- name: "RHELOSP-148708 Verify that Alertmanager pod didn't respawn"
   ansible.builtin.shell:
     cmd: |
       oc get pods | grep alertmanager-default | wc -l
@@ -88,8 +79,7 @@
   failed_when: "cmd_output.stdout|int !=0"
   changed_when: false
 
-- name: "RHELOSP-148709"
-# description: "Verify that elasticsearch pod didn't respawn"
+- name: "RHELOSP-148709 Verify that elasticsearch pod didn't respawn"
   ansible.builtin.shell:
     cmd: |
       oc get pods | grep elasticsearch | wc -l
@@ -97,8 +87,7 @@
   failed_when: "cmd_output.stdout|int !=0"
   changed_when: false
 
-- name: "RHELOSP-176047"
-# description: "Remove obesrvabilityStrategy"
+- name: "RHELOSP-176047 Remove obesrvabilityStrategy"
   ansible.builtin.shell:
      cmd: |
        oc patch stf/default --type='json'  -p '[{"op": "remove", "path": "/spec/observabilityStrategy"}]'

--- a/roles/test_qdr/tasks/main.yml
+++ b/roles/test_qdr/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
-- name: RHELOSP-60117
-#     Description: Check that metrics_qdr container is running
+- name: RHELOSP-60117 Check that metrics_qdr container is running
   ansible.builtin.shell: |
     set -o pipefail
     {{ container_bin }} ps | grep {{ qdr_container_name }}
@@ -19,8 +18,7 @@
   ansible.builtin.debug:
     var: bus_addr
 
-- name: RHELOSP-60410
-#     Description: Get number of messages received from QDR
+- name: RHELOSP-60410 Get number of messages received from QDR
   ansible.builtin.shell: |
     set -o pipefail
     {{ container_bin }} exec {{ qdr_container_name }} qdstat -b {{ bus_addr.stdout }}:5666 -g | grep "Ingress Count" | awk '{print $3}'

--- a/roles/test_sensubility/tasks/main.yml
+++ b/roles/test_sensubility/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-- name: "RHELOSP-57534"
-# description: "Test health status"
+- name: "RHELOSP-57534 Test health status"
   ansible.builtin.include_tasks:
     file: test_health_status.yml

--- a/roles/test_sensubility/tasks/test_health_status.yml
+++ b/roles/test_sensubility/tasks/test_health_status.yml
@@ -1,8 +1,7 @@
   #In this test we choose one container (logrotate_crond),checking that it is running 
   #and then stopping the container and starting it again and checking that its health status changes accordingly.
 
-- name: RHELOSP-176011
-  # Description: Check that logrotate_crond container is running on controller-0
+- name: RHELOSP-176011 Check that logrotate_crond container is running on controller-0
   delegate_to: "{{ groups['overcloud_nodes'][0] }}"
   become: true
   delegate_facts: True
@@ -15,8 +14,7 @@
 
 
 
-- name: RHELOSP-176012
-  # Description: Stop logrotate_crond container on controller-0
+- name: RHELOSP-176012 Stop logrotate_crond container on controller-0
   ansible.builtin.shell:
     cmd: |
        systemctl stop tripleo_logrotate_crond
@@ -27,8 +25,7 @@
 
 
 
-- name: RHELOSP-176037
-  # Description: Check that logrotate_crond container has stopped
+- name: RHELOSP-176037 Check that logrotate_crond container has stopped
   ansible.builtin.shell: |
     {{ container_bin }} ps | grep logrotate_crond 
   delegate_to: "{{ groups['overcloud_nodes'][0] }}"
@@ -39,8 +36,7 @@
  
 
 
-- name: RHELOSP-176036
-  # Description: Check that health status of container changed to 0
+- name: RHELOSP-176036 Check that health status of container changed to 0
   ansible.builtin.shell:
     cmd: /usr/bin/curl -k {{ prom_auth_string }} -g https://{{ prom_url }}/api/v1/query? --data-urlencode 'query=last_over_time(sensubility_container_health_status{process="logrotate_crond",host="{{ groups['overcloud_nodes'][0] }}"}[10m])' | grep -oP '(?<="value":).*' | awk -F, '{ print $2 }' | grep -o '[0-9]\+' | grep 0 | wc -l
     #  /usr/bin/curl -k {{ prom_auth_string }} \
@@ -53,8 +49,7 @@
   
 
 
-- name: RHELOSP-176035
-  # Description: Start logrotate_crond container
+- name: RHELOSP-176035 Start logrotate_crond container
   ansible.builtin.shell:
     cmd: |
        systemctl start tripleo_logrotate_crond
@@ -65,8 +60,7 @@
 
 
 
-- name: RHELOSP-176038
-  # Description: Check that health status of container changed to 1
+- name: RHELOSP-176038 Check that health status of container changed to 1
   ansible.builtin.shell:
     cmd: >-
       /usr/bin/curl -k {{ prom_auth_string }} \

--- a/roles/test_snmp_traps/tasks/main.yml
+++ b/roles/test_snmp_traps/tasks/main.yml
@@ -3,8 +3,7 @@
 # Following procedure on https://infrawatch.github.io/documentation/#configuring-snmp-traps_assembly-advanced-features
 # Assuming we're in the right project already...
 
-- name: "RHELOSP-144987"
-  # description: "Set the alerting.alertmanager.receivers.snmpTraps parameters"
+- name: "RHELOSP-144987 Set the alerting.alertmanager.receivers.snmpTraps parameters"
   ansible.builtin.shell:
     cmd: |
       oc patch stf/default --type merge -p '{"spec": {"alerting": {"alertmanager": {"receivers": {"snmpTraps": {"enabled": true, "target": "10.10.10.10" }}}}}}'
@@ -13,15 +12,13 @@
   failed_when: cmd_output.rc != 0
 
 
-- name: "RHELOSP-144966"
-  # description: "Interrupt metrics flow by preventing the QDR from running"
+- name: "RHELOSP-144966 Interrupt metrics flow by preventing the QDR from running"
   ansible.builtin.shell:
     cmd: |
       for i in {1..30}; do oc delete po -l application=default-interconnect; sleep 1; done
   changed_when: false
 
-- name: "RHELOSP-144481"
-  # description: "Check for snmpTraps logs"
+- name: "RHELOSP-144481 Check for snmpTraps logs"
   ansible.builtin.shell:
     cmd: |
       oc logs -l "app=default-snmp-webhook"  | grep "Sending SNMP trap" | wc -l

--- a/roles/test_verify_email/tasks/main.yml
+++ b/roles/test_verify_email/tasks/main.yml
@@ -1,8 +1,7 @@
 ---
 # tasks file for roles/test_verify_email
 
-- name: "RHELOSP-176042"
-  # "Create the alert"
+- name: "RHELOSP-176042 Create the alert"
   ansible.builtin.shell:
     cmd: |
       oc apply -f - <<EOF
@@ -26,22 +25,19 @@
   register: cmd_output
   failed_when: cmd_output.rc != 0
 
-- name: "RHELOSP-176043"
-  # "Patch the ServiceTelemetry object for the STF deployment"
+- name: "RHELOSP-176043 Patch the ServiceTelemetry object for the STF deployment"
   ansible.builtin.shell:
     cmd: |
       oc patch stf default --type merge -p '{"spec": {"alertmanagerConfigManifest": "apiVersion: v1\nkind: Secret\nmetadata:\n  name: 'alertmanager-default'\n  namespace: 'service-telemetry'\ntype: Opaque\nstringData:\n  alertmanager.yaml: |-\n    global:\n      resolve_timeout: 10m\n    route:\n      group_by: ['job']\n      group_wait: 30s\n      group_interval: 5m\n      repeat_interval: 12h\n      receiver: 'email'\n    receivers:\n    - name: 'email'\n      - email_configs:\n      - to: mx@redhat.com"}}'
   changed_when: false
 
-- name: "RHELOSP-176044" 
-  # "Interrupt metrics flow by preventing the QDR from running"
+- name: "RHELOSP-176044 Interrupt metrics flow by preventing the QDR from running"
   ansible.builtin.shell:
     cmd: |
       for i in {1..60}; do oc delete po -l application=default-interconnect; sleep 1; done
   changed_when: false
 
-- name: "RHELOSP-176045"
-  # "Check for alertmanager logs"
+- name: "RHELOSP-176045 Check for alertmanager logs"
   ansible.builtin.shell:
     cmd: |
       oc logs alertmanager-default-0 -c alertmanager  | grep 'receiver=email' | wc -l
@@ -49,8 +45,7 @@
   failed_when: "cmd_output.stdout|int == 0"
   changed_when: false
 
-- name: "RHELOSP-176046" 
-  # "Remove alertmanagerConfigManifest from the ServiceTelemetry object"
+- name: "RHELOSP-176046 Remove alertmanagerConfigManifest from the ServiceTelemetry object"
   ansible.builtin.shell:
     cmd: |
       oc patch stf/default --type='json' -p '[{"op": "remove", "path": "/spec/alertmanagerConfigManifest"}]'


### PR DESCRIPTION
The tasks were previously renamed to just be the test id, due to limitations in the custom_logger callbaack plugin. This was addressed, and the test_report_result reports in the correct format now, so the names can be reverted.
This makes reports more grokable, since the summary_result.log contains a list of the passed/failed tests with the task names.

Depends-On: https://github.com/infrawatch/feature-verification-tests/pull/177