### PR TITLE
[ci] Update the test playbooks to ignore errors in tests

### DIFF
--- a/ci/run_autoscaling_osp18.yml
+++ b/ci/run_autoscaling_osp18.yml
@@ -77,6 +77,7 @@
         - name: "Run Telemetry Autoscaling tests"
           ansible.builtin.import_role:
             name: telemetry_autoscaling
+          ignore_errors: true
 
       always:
         - name: Revert the version update

--- a/ci/run_verify_metrics_osp18.yml
+++ b/ci/run_verify_metrics_osp18.yml
@@ -26,3 +26,4 @@
     - name: "Run Telemetry Verify Metrics tests"
       ansible.builtin.import_role:
         name: telemetry_verify_metrics
+      ignore_errors: true


### PR DESCRIPTION
The tests should be run with ignore_errors: true in order to run all the tests. Without this, the tests will only run until the first failing test. This change is inline with the way the other test roles are included