### PR TITLE
[test_alerts] Update the command for checking the alert in alert manager

### DIFF
--- a/roles/test_alerts/tasks/test_creating_a_standard_alert_route_in_alert_manager.yml
+++ b/roles/test_alerts/tasks/test_creating_a_standard_alert_route_in_alert_manager.yml
@@ -43,9 +43,9 @@
 - name: "RHELOSP-148698 Verify that the alert is active in Alertmanager"
   ansible.builtin.shell: 
     cmd: >-
-      oc exec -it prometheus-default-0 -c prometheus -- /bin/sh -c 'wget --header \
+      oc exec -it prometheus-default-0 -c prometheus -- /bin/sh -c 'curl -k -H \
         "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
-        https://default-alertmanager-proxy:9095/api/v1/alerts -q -O -' | grep 'active' | grep 'Collectd metrics receive rate is zero' | wc -l
+        https://default-alertmanager-proxy:9095/api/v1/alerts' | grep 'active' | grep 'Collectd metrics receive rate is zero' | wc -l
   register: cmd_output
   changed_when: false
   failed_when: cmd_output.stdout|int == 0


### PR DESCRIPTION
The prometheus container in the prometheus-default pod no longer has wget included.
The equivalent curl command is used instead.