### PR TITLE
Adding retry to the ceilometer_cpu metric task

### DIFF
--- a/roles/telemetry_autoscaling/tasks/creating_stack.yml
+++ b/roles/telemetry_autoscaling/tasks/creating_stack.yml
@@ -72,6 +72,8 @@
     # source ~/overcloudrc;
     {{ openstack_cmd }} metric list
   register: result
+  retries: 12
+  delay: 10
   failed_when: '"ceilometer_cpu" not in result.stdout'
 
 - name: Print the result

--- a/roles/telemetry_autoscaling/tasks/creating_stack.yml
+++ b/roles/telemetry_autoscaling/tasks/creating_stack.yml
@@ -74,7 +74,7 @@
   register: result
   retries: 12
   delay: 10
-  failed_when: '"ceilometer_cpu" not in result.stdout'
+  until: '"ceilometer_cpu" in result.stdout'
 
 - name: Print the result
   ansible.builtin.debug:


### PR DESCRIPTION
There is not enough time for that metric to be scraped. We should add a retry to the task.
Worst case scenario the  metric can take 2 minutes to appeara.