### PR TITLE
Add block/always to tests to separate test procedure from cleanup

### DIFF
--- a/roles/test_alerts/tasks/test_create_an_alert.yml
+++ b/roles/test_alerts/tasks/test_create_an_alert.yml
@@ -3,34 +3,36 @@
 # Assuming we're in the right project already...
 # Following procedure on https://infrawatch.github.io/documentation/#creating-an-alert-rule-in-prometheus_assembly-advanced-features
 
-- name: "RHELOSP-144965 Create the alert"
-  ansible.builtin.shell:
-    cmd: |
-      oc apply -f - <<EOF
-      apiVersion: {{ observability_api }}/v1
-      kind: PrometheusRule
-      metadata:
-        creationTimestamp: null
-        labels:
-          prometheus: default
-          role: alert-rules
-        name: prometheus-alarm-rules
-        namespace: service-telemetry
-      spec:
-        groups:
-          - name: ./openstack.rules
-            rules:
-              - alert: Collectd metrics receive rate is zero
-                expr: rate(sg_total_collectd_msg_received_count[1m]) == 0
-      EOF
-  changed_when: false
-  register: cmd_output
-  failed_when: cmd_output.rc != 0
+- name: "Do the test procedure"
+  block:
+    - name: "RHELOSP-144965 Create the alert"
+      ansible.builtin.shell:
+        cmd: |
+          oc apply -f - <<EOF
+          apiVersion: {{ observability_api }}/v1
+          kind: PrometheusRule
+          metadata:
+            creationTimestamp: null
+            labels:
+              prometheus: default
+              role: alert-rules
+            name: prometheus-alarm-rules
+            namespace: service-telemetry
+          spec:
+            groups:
+              - name: ./openstack.rules
+                rules:
+                  - alert: Collectd metrics receive rate is zero
+                    expr: rate(sg_total_collectd_msg_received_count[1m]) == 0
+          EOF
+      changed_when: false
+      register: cmd_output
+      failed_when: cmd_output.rc != 0
 
-- name: "RHELOSP-144480 Check that the alert was created"
-  ansible.builtin.command:
-    cmd: |
-      curl -k {{ prom_auth_string }} https://{{ prom_url }}/api/v1/rules
-  register: cmd_output
-  changed_when: false
-  failed_when: cmd_output.rc != 0
+    - name: "RHELOSP-144480 Check that the alert was created"
+      ansible.builtin.command:
+        cmd: |
+          curl -k {{ prom_auth_string }} https://{{ prom_url }}/api/v1/rules
+      register: cmd_output
+      changed_when: false
+      failed_when: cmd_output.rc != 0

--- a/roles/test_alerts/tasks/test_creating_a_standard_alert_route_in_alert_manager.yml
+++ b/roles/test_alerts/tasks/test_creating_a_standard_alert_route_in_alert_manager.yml
@@ -2,72 +2,74 @@
 # Test creating an alert route in alertmanager following the procedure in: https://infrawatch.github.io/documentation/#creating-an-alert-route-in-alertmanager_assembly-advanced-features
 
 # Pre-check: is the value of global.timeout = 5m in the alertmanager secret
-  # TODO: put the patch into a file. and use --patch-file instead of -p OR slurp the file from files/
-- name: "RHELOSP-144965 Patch the ServiceTelemetry object for the STF deployment"
-  ansible.builtin.shell:
-    cmd: |
-      oc patch stf default --type merge -p '{"spec": {"alertmanagerConfigManifest": "apiVersion: v1\nkind: Secret\nmetadata:\n  name: 'alertmanager-default'\n  namespace: 'service-telemetry'\ntype: Opaque\nstringData:\n  alertmanager.yaml: |-\n    global:\n      resolve_timeout: 10m\n    route:\n      group_by: ['job']\n      group_wait: 30s\n      group_interval: 5m\n      repeat_interval: 12h\n      receiver: 'null'\n    receivers:\n    - name: 'null'\n"}}'
-  changed_when: false
-  register: cmd_output
-  failed_when: cmd_output.rc != 0
 
-- name: "Show the command output"
-  ansible.builtin.debug:
-    var: cmd_output
+- name: "Do the test procedure"
+  block:
+      # TODO: put the patch into a file. and use --patch-file instead of -p OR slurp the file from files/
+    - name: "RHELOSP-144965 Patch the ServiceTelemetry object for the STF deployment"
+      ansible.builtin.shell:
+        cmd: |
+          oc patch stf default --type merge -p '{"spec": {"alertmanagerConfigManifest": "apiVersion: v1\nkind: Secret\nmetadata:\n  name: 'alertmanager-default'\n  namespace: 'service-telemetry'\ntype: Opaque\nstringData:\n  alertmanager.yaml: |-\n    global:\n      resolve_timeout: 10m\n    route:\n      group_by: ['job']\n      group_wait: 30s\n      group_interval: 5m\n      repeat_interval: 12h\n      receiver: 'null'\n    receivers:\n    - name: 'null'\n"}}'
+      changed_when: false
+      register: cmd_output
+      failed_when: cmd_output.rc != 0
 
-  # oc get secret alertmanager-default -o go-template='{{index .data "alertmanager.yaml" | base64decode }}'
-  # Can't use -o go-template because of the "{{" and "}}", which are mistaken for templating syntax.
-  # The alertmanager.yaml key needed to be surrounded by [".."] because of the period in the key name.
-- name: "Get the updated secret"
-  ansible.builtin.shell:
-    cmd: |
-      oc get secret alertmanager-default -ojson | jq '.data | .["alertmanager.yaml"]'
-  register: cmd_output
-  changed_when: false
+    - name: "Show the command output"
+      ansible.builtin.debug:
+        var: cmd_output
 
-- name: "Decode the updated secret"
-  ansible.builtin.set_fact:
-    alertmanager_secret: "{{ cmd_output.stdout | b64decode | to_yaml }}"
+      # oc get secret alertmanager-default -o go-template='{{index .data "alertmanager.yaml" | base64decode }}'
+      # Can't use -o go-template because of the "{{" and "}}", which are mistaken for templating syntax.
+      # The alertmanager.yaml key needed to be surrounded by [".."] because of the period in the key name.
+    - name: "Get the updated secret"
+      ansible.builtin.shell:
+        cmd: |
+          oc get secret alertmanager-default -ojson | jq '.data | .["alertmanager.yaml"]'
+      register: cmd_output
+      changed_when: false
 
-- name: "Show the alertmanager.yaml contents"
-  ansible.builtin.debug:
-    var: alertmanager_secret
+    - name: "Decode the updated secret"
+      ansible.builtin.set_fact:
+        alertmanager_secret: "{{ cmd_output.stdout | b64decode | to_yaml }}"
 
-- name: "RHELOSP-148697 Interrupt metrics flow by preventing the QDR from running"
-  ansible.builtin.shell:
-    cmd: |
-      for i in {1..15}; do oc delete po -l application=default-interconnect; sleep 1; done
-  changed_when: false
+    - name: "Show the alertmanager.yaml contents"
+      ansible.builtin.debug:
+        var: alertmanager_secret
 
-
-- name: "RHELOSP-148698 Verify that the alert is active in Alertmanager"
-  ansible.builtin.shell: 
-    cmd: >-
-      oc exec -it prometheus-default-0 -c prometheus -- /bin/sh -c 'curl -k -H \
-        "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
-        https://default-alertmanager-proxy:9095/api/v1/alerts' | grep 'active' | grep 'Collectd metrics receive rate is zero'
-  register: cmd_output
-  changed_when: false
-  failed_when: cmd_output.stdout_lines | length == 0
-
-- name: "RHELOSP-148699 Verify that the alert is firing in Prometheus"
-  ansible.builtin.shell:
-    cmd: >-
-      /usr/bin/curl -k {{ prom_auth_string }} -g https://{{ prom_url }}/api/v1/alerts | grep 'firing' | grep 'Collectd metrics receive rate is zero'
-  register: cmd_output
-  changed_when: false
-  failed_when: cmd_output.stdout_lines | length == 0
+    - name: "RHELOSP-148697 Interrupt metrics flow by preventing the QDR from running"
+      ansible.builtin.shell:
+        cmd: |
+          for i in {1..15}; do oc delete po -l application=default-interconnect; sleep 1; done
+      changed_when: false
 
 
-- name: "Wait 2 minutes to make sure all SG pods are back to normal"
-  ansible.builtin.pause:
-    minutes: 2
+    - name: "RHELOSP-148698 Verify that the alert is active in Alertmanager"
+      ansible.builtin.shell:
+        cmd: >-
+          oc exec -it prometheus-default-0 -c prometheus -- /bin/sh -c 'curl -k -H \
+            "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+            https://default-alertmanager-proxy:9095/api/v1/alerts' | grep 'active' | grep 'Collectd metrics receive rate is zero'
+      register: cmd_output
+      changed_when: false
+      failed_when: cmd_output.stdout_lines | length == 0
+
+    - name: "RHELOSP-148699 Verify that the alert is firing in Prometheus"
+      ansible.builtin.shell:
+        cmd: >-
+          /usr/bin/curl -k {{ prom_auth_string }} -g https://{{ prom_url }}/api/v1/alerts | grep 'firing' | grep 'Collectd metrics receive rate is zero'
+      register: cmd_output
+      changed_when: false
+      failed_when: cmd_output.stdout_lines | length == 0
+  always:
+    - name: "Wait 2 minutes to make sure all SG pods are back to normal"
+      ansible.builtin.pause:
+        minutes: 2
 
 
-- name: "RHELOSP-176039 Remove alertmanagerConfigManifest from the ServiceTelemetry object"
-  ansible.builtin.shell:
-    cmd: |
-      oc patch stf/default --type='json' -p '[{"op": "remove", "path": "/spec/alertmanagerConfigManifest"}]'
-  changed_when: false
-  register: cmd_output
-  failed_when: cmd_output.rc != 0
+    - name: "RHELOSP-176039 Remove alertmanagerConfigManifest from the ServiceTelemetry object"
+      ansible.builtin.shell:
+        cmd: |
+          oc patch stf/default --type='json' -p '[{"op": "remove", "path": "/spec/alertmanagerConfigManifest"}]'
+      changed_when: false
+      register: cmd_output
+      failed_when: cmd_output.rc != 0

--- a/roles/test_snmp_traps/tasks/main.yml
+++ b/roles/test_snmp_traps/tasks/main.yml
@@ -3,31 +3,33 @@
 # Following procedure on https://infrawatch.github.io/documentation/#configuring-snmp-traps_assembly-advanced-features
 # Assuming we're in the right project already...
 
-- name: "RHELOSP-144987 Set the alerting.alertmanager.receivers.snmpTraps parameters"
-  ansible.builtin.shell:
-    cmd: |
-      oc patch stf/default --type merge -p '{"spec": {"alerting": {"alertmanager": {"receivers": {"snmpTraps": {"enabled": true, "target": "10.10.10.10" }}}}}}'
-  changed_when: false
-  register: cmd_output
-  failed_when: cmd_output.rc != 0
+- name: "Do the test procedure"
+  block:
+    - name: "RHELOSP-144987 Set the alerting.alertmanager.receivers.snmpTraps parameters"
+      ansible.builtin.shell:
+        cmd: |
+          oc patch stf/default --type merge -p '{"spec": {"alerting": {"alertmanager": {"receivers": {"snmpTraps": {"enabled": true, "target": "10.10.10.10" }}}}}}'
+      changed_when: false
+      register: cmd_output
+      failed_when: cmd_output.rc != 0
 
 
-- name: "RHELOSP-144966 Interrupt metrics flow by preventing the QDR from running"
-  ansible.builtin.shell:
-    cmd: |
-      for i in {1..30}; do oc delete po -l application=default-interconnect; sleep 1; done
-  changed_when: false
+    - name: "RHELOSP-144966 Interrupt metrics flow by preventing the QDR from running"
+      ansible.builtin.shell:
+        cmd: |
+          for i in {1..30}; do oc delete po -l application=default-interconnect; sleep 1; done
+      changed_when: false
 
-- name: "RHELOSP-144481 Check for snmpTraps logs"
-  ansible.builtin.shell:
-    cmd: |
-      oc logs -l "app=default-snmp-webhook"  | grep "Sending SNMP trap"
-  register: cmd_output
-  changed_when: false
-  failed_when: "cmd_output.stdout_lines | length == 0"
+    - name: "RHELOSP-144481 Check for snmpTraps logs"
+      ansible.builtin.shell:
+        cmd: |
+          oc logs -l "app=default-snmp-webhook"  | grep "Sending SNMP trap"
+      register: cmd_output
+      changed_when: false
+      failed_when: "cmd_output.stdout_lines | length == 0"
 
-
-- name: "Wait 2 minutes to make sure all SG pods are back to normal"
-  ansible.builtin.pause:
-    minutes: 2
-  changed_when: false
+  always:
+    - name: "Wait 2 minutes to make sure all SG pods are back to normal"
+      ansible.builtin.pause:
+        minutes: 2
+      changed_when: false

--- a/roles/test_verify_email/tasks/main.yml
+++ b/roles/test_verify_email/tasks/main.yml
@@ -5,54 +5,57 @@
     name: test_alerts
     tasks_from: get_observability_api.yml
 
-- name: "RHELOSP-176042 Create the alert"
-  ansible.builtin.shell:
-    cmd: |
-      oc apply -f - <<EOF
-      apiVersion: {{ observability_api }}/v1
-      kind: PrometheusRule
-      metadata:
-        creationTimestamp: null
-        labels:
-          prometheus: default
-          role: alert-rules
-        name: prometheus-alarm-rules
-        namespace: service-telemetry
-      spec:
-        groups:
-          - name: ./openstack.rules
-            rules:
-              - alert: Collectd metrics receive rate is zero
-                expr: rate(sg_total_collectd_msg_received_count[1m]) == 0
-      EOF
-  changed_when: false
-  register: cmd_output
-  failed_when: cmd_output.rc != 0
+- name: "Do the test procedure"
+  block:
+    - name: "RHELOSP-176042 Create the alert"
+      ansible.builtin.shell:
+        cmd: |
+          oc apply -f - <<EOF
+          apiVersion: {{ observability_api }}/v1
+          kind: PrometheusRule
+          metadata:
+            creationTimestamp: null
+            labels:
+              prometheus: default
+              role: alert-rules
+            name: prometheus-alarm-rules
+            namespace: service-telemetry
+          spec:
+            groups:
+              - name: ./openstack.rules
+                rules:
+                  - alert: Collectd metrics receive rate is zero
+                    expr: rate(sg_total_collectd_msg_received_count[1m]) == 0
+          EOF
+      changed_when: false
+      register: cmd_output
+      failed_when: cmd_output.rc != 0
 
-- name: "RHELOSP-176043 Patch the ServiceTelemetry object for the STF deployment"
-  ansible.builtin.shell:
-    cmd: |
-      oc patch stf default --type merge -p '{"spec": {"alertmanagerConfigManifest": "apiVersion: v1\nkind: Secret\nmetadata:\n  name: 'alertmanager-default'\n  namespace: 'service-telemetry'\ntype: Opaque\nstringData:\n  alertmanager.yaml: |-\n    global:\n      resolve_timeout: 10m\n      smtp_smarthost: localhost:25\n      smtp_from: lesik@gmail.com\n      smtp_auth_username: alertmanager\n      smtp_auth_password: password\n    route:\n      group_by: ['job']\n      group_wait: 30s\n      group_interval: 5m\n      repeat_interval: 12h\n      receiver: 'email'\n    receivers:\n    - name: 'email'\n      email_configs:\n      - to: mx@redhat.com"}}'
-  changed_when: false
+    - name: "RHELOSP-176043 Patch the ServiceTelemetry object for the STF deployment"
+      ansible.builtin.shell:
+        cmd: |
+          oc patch stf default --type merge -p '{"spec": {"alertmanagerConfigManifest": "apiVersion: v1\nkind: Secret\nmetadata:\n  name: 'alertmanager-default'\n  namespace: 'service-telemetry'\ntype: Opaque\nstringData:\n  alertmanager.yaml: |-\n    global:\n      resolve_timeout: 10m\n      smtp_smarthost: localhost:25\n      smtp_from: lesik@gmail.com\n      smtp_auth_username: alertmanager\n      smtp_auth_password: password\n    route:\n      group_by: ['job']\n      group_wait: 30s\n      group_interval: 5m\n      repeat_interval: 12h\n      receiver: 'email'\n    receivers:\n    - name: 'email'\n      email_configs:\n      - to: mx@redhat.com"}}'
+      changed_when: false
 
-- name: "RHELOSP-176044 Interrupt metrics flow by preventing the QDR from running"
-  ansible.builtin.shell:
-    cmd: |
-      for i in {1..60}; do oc delete po -l application=default-interconnect; sleep 1; done
-  changed_when: false
+    - name: "RHELOSP-176044 Interrupt metrics flow by preventing the QDR from running"
+      ansible.builtin.shell:
+        cmd: |
+          for i in {1..60}; do oc delete po -l application=default-interconnect; sleep 1; done
+      changed_when: false
 
-- name: "RHELOSP-176045 Check for alertmanager logs"
-  ansible.builtin.shell:
-    cmd: |
-      oc logs alertmanager-default-0 -c alertmanager  | grep 'receiver=email'
-  register: cmd_output
-  failed_when: "cmd_output.stdout_lines | length == 0"
-  changed_when: false
+    - name: "RHELOSP-176045 Check for alertmanager logs"
+      ansible.builtin.shell:
+        cmd: |
+          oc logs alertmanager-default-0 -c alertmanager  | grep 'receiver=email'
+      register: cmd_output
+      failed_when: "cmd_output.stdout_lines | length == 0"
+      changed_when: false
 
-- name: "RHELOSP-176046 Remove alertmanagerConfigManifest from the ServiceTelemetry object"
-  ansible.builtin.shell:
-    cmd: |
-      oc patch stf/default --type='json' -p '[{"op": "remove", "path": "/spec/alertmanagerConfigManifest"}]'
-  register: cmd_output
-  failed_when: cmd_output.rc != 0
-  changed_when: false
+  always:
+    - name: "RHELOSP-176046 Remove alertmanagerConfigManifest from the ServiceTelemetry object"
+      ansible.builtin.shell:
+        cmd: |
+          oc patch stf/default --type='json' -p '[{"op": "remove", "path": "/spec/alertmanagerConfigManifest"}]'
+      register: cmd_output
+      failed_when: cmd_output.rc != 0
+      changed_when: false


### PR DESCRIPTION
This let the cleanup always be done, even when there are test failures.