### PR TITLE
[test_verify_email] Add retry/until when checking for alertmanager logs

### DIFF
--- a/roles/test_verify_email/tasks/main.yml
+++ b/roles/test_verify_email/tasks/main.yml
@@ -46,9 +46,11 @@
     - name: "RHELOSP-176045 Check for alertmanager logs"
       ansible.builtin.shell:
         cmd: |
-          oc logs alertmanager-default-0 -c alertmanager  | grep 'receiver=email'
+          oc logs alertmanager-default-0 -c alertmanager
       register: cmd_output
-      failed_when: "cmd_output.stdout_lines | length == 0"
+      retries: 18
+      delay: 10
+      until: "'receiver=email' in cmd_output.stdout"
       changed_when: false
 
   always:


### PR DESCRIPTION
The updates also provides more info when debugging since the output isn't "filtered" through grep