### PR TITLE
Add service and file tests to the logging job

### DIFF
--- a/ci/logging_tests_controller.yml
+++ b/ci/logging_tests_controller.yml
@@ -23,6 +23,29 @@
       - openshift
       - openstack-operators
       - openshift-logging
+    common_service_test_id: "RHOSO-12675"
+    common_service_nspace: openshift-logging
+    common_service_list:
+      - cluster-logging-operator-metrics
+      - logging-loki-compactor-grpc
+      - logging-loki-compactor-http
+      - logging-loki-distributor-grpc
+      - logging-loki-distributor-http
+      - logging-loki-gateway-http
+      - logging-loki-gossip-ring
+      - logging-loki-index-gateway-grpc
+      - logging-loki-index-gateway-http
+      - logging-loki-ingester-grpc
+      - logging-loki-ingester-http
+      - logging-loki-querier-grpc
+      - logging-loki-querier-http
+      - logging-loki-query-frontend-grpc
+      - logging-loki-query-frontend-http
+      - logging-view-plugin
+      - openstack-logging
+    common_file_test_id: "RHOSO-12754"
+    common_file_list:
+      - /etc/rsyslog.d/10-telemetry.conf
   tasks:
     - name: "Verify logging infrastructure components"
       ansible.builtin.import_role:

--- a/roles/common/README.md
+++ b/roles/common/README.md
@@ -171,7 +171,6 @@ can be set at the play level.
           name: common
         vars:
           common_project_test_id: "RHOSO-12668"
-          common_service_nspace: openshift-logging
           common_project_list:
             - openshift-openstack-infra
             - openshift
@@ -181,6 +180,7 @@ can be set at the play level.
           name: common
         vars:
           common_service_test_id: "RHOSO-12675"
+          common_service_nspace: openshift-logging
           common_service_list:
             - cluster-logging-operator-metrics
             - logging-loki-compactor-grpc

--- a/roles/common/README.md
+++ b/roles/common/README.md
@@ -67,6 +67,21 @@ For project_tests.yml tasks:
     common_project_list
       - list of projects to validate
 
+For service_tests.yml tasks:
+
+    common_service_test_id
+      - polarion ID number for each test
+    common_service_nspace
+      - namespace
+    common_service_list
+      - list of services to validate
+
+For file_tests.yml tasks:
+
+    common_file_test_id
+      - polarion ID number for each test
+    common_file_list
+      - list of files to validate
 
 For manifest_tests.yml tasks:
 
@@ -156,10 +171,42 @@ can be set at the play level.
           name: common
         vars:
           common_project_test_id: "RHOSO-12668"
+          common_service_nspace: openshift-logging
           common_project_list:
             - openshift-openstack-infra
             - openshift
+    
+      - name: "Verify services"
+        ansible.builtin.import_role:
+          name: common
+        vars:
+          common_service_test_id: "RHOSO-12675"
+          common_service_list:
+            - cluster-logging-operator-metrics
+            - logging-loki-compactor-grpc
+            - logging-loki-compactor-http
+            - logging-loki-distributor-grpc
+            - logging-loki-distributor-http
+            - logging-loki-gateway-http
+            - logging-loki-gossip-ring
+            - logging-loki-index-gateway-grpc
+            - logging-loki-index-gateway-http
+            - logging-loki-ingester-grpc
+            - logging-loki-ingester-http
+            - logging-loki-querier-grpc
+            - logging-loki-querier-http
+            - logging-loki-query-frontend-grpc
+            - logging-loki-query-frontend-http
+            - logging-view-plugin
+            - openstack-logging
 
+      - name: "Verify files"
+        ansible.builtin.import_role:
+          name: common
+        vars:
+          common_file_test_id: "RHOSO-12754"
+          common_file_list:
+            - /etc/rsyslog.d/10-telemetry.conf
 
       - name: "Verify crd"
         ansible.builtin.import_role:

--- a/roles/common/tasks/file_tests.yml
+++ b/roles/common/tasks/file_tests.yml
@@ -1,0 +1,10 @@
+---
+- name: Get stats for file - "{{ item }}"
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  register: fstats
+  failed_when: 
+    - fstats.stat.pw_name != "root"
+    - fstats.stat.size | int < 300
+    - not fstats.stat.exists
+    - not fstats.stat.isreg

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -27,6 +27,21 @@
     - common_project_list is defined
   ansible.builtin.include_tasks: "project_tests.yml"
   loop: "{{ common_project_list }}"
+
+- name: "Run service tests"
+  when:
+    - common_service_test_id is defined
+    - common_service_nspace is defined
+    - common_service_list is defined
+  ansible.builtin.include_tasks: "service_tests.yml"
+  loop: "{{ common_service_list }}"
+
+- name: "Run file tests"
+  when:
+    - common_file_test_id is defined
+    - common_file_list is defined
+  ansible.builtin.include_tasks: "file_tests.yml"
+  loop: "{{ common_file_list }}"
   
 - name: "Run manifest tests"
   when:

--- a/roles/common/tasks/service_tests.yml
+++ b/roles/common/tasks/service_tests.yml
@@ -1,0 +1,14 @@
+---
+- name: Verify Service - "{{ item }}"
+  ansible.builtin.shell:
+    cmd: |
+      oc get service -n "{{ common_service_nspace }}" "{{ item }}"
+  changed_when: false
+  register: output
+
+- name: Verify service is running "{{ common_service_test_id }}"
+  ansible.builtin.assert:
+    that:
+      - "'NotFound' not in output.stderr"
+    success_msg: "service {{ item }} is running."
+    fail_msg: "service {{ item }} not running. Error: {{ output.stderr }}"

--- a/roles/common/tasks/service_tests.yml
+++ b/roles/common/tasks/service_tests.yml
@@ -6,7 +6,9 @@
   changed_when: false
   register: output
 
-- name: Verify service is running "{{ common_service_test_id }}"
+- name: |
+    Verify {{ item }} service is running
+    {{ common_service_test_id }}
   ansible.builtin.assert:
     that:
       - "'NotFound' not in output.stderr"


### PR DESCRIPTION
OSPRH-9659

This covers adding the tasks from https://github.com/infrawatch/feature-verification-tests/pull/123 into a spearate PR, which will include:

    Update roles/common/tasks/main.yml
    Add roles/common/tasks/service_tests.yml
    Add roles/common/tasks/file_tests.yml
    Add service_tests and file_tests to the ci/logging* playbook
    Update the README file to document the configuration options