### PR TITLE
[common] Fix failure condition in file test

### DIFF
--- a/roles/common/tasks/file_tests.yml
+++ b/roles/common/tasks/file_tests.yml
@@ -3,8 +3,8 @@
   ansible.builtin.stat:
     path: "{{ item }}"
   register: fstats
-  failed_when: 
-    - fstats.stat.pw_name != "root"
-    - fstats.stat.size | int < 300
-    - not fstats.stat.exists
-    - not fstats.stat.isreg
+  failed_when:
+    - ((fstats.stat.pw_name != "root") or
+      (fstats.stat.size | int < 300) or
+      (not fstats.stat.exists) or
+      (not fstats.stat.isreg) )

--- a/roles/common/tasks/file_tests.yml
+++ b/roles/common/tasks/file_tests.yml
@@ -3,8 +3,20 @@
   ansible.builtin.stat:
     path: "{{ item }}"
   register: fstats
-  failed_when:
-    - ((fstats.stat.pw_name != "root") or
-      (fstats.stat.size | int < 300) or
-      (not fstats.stat.exists) or
-      (not fstats.stat.isreg) )
+
+- name: |
+    Verify the file {{ item }} exists
+    {{ common_file_test_id }}
+  ansible.builtin.assert:
+    that:
+      - fstats.stat.exists
+      - fstats.stat.pw_name == "root"
+      - fstats.stat.size | int > 300
+      - fstats.stat.isreg
+    fail_msg: |
+      File {{ item }} does not meet the required conditions:
+      {%- if not fstats.stat.exists %} file does not exist.{% endif %}
+      {%- if fstats.stat.exists and fstats.stat.pw_name != "root" %} file owner must be root (got {{ fstats.stat.pw_name }});{% endif %}
+      {%- if fstats.stat.exists and fstats.stat.size | int < 300 %} file must be larger than 300 bytes (got {{ fstats.stat.size }} bytes);{% endif %}
+      {%- if fstats.stat.exists and not fstats.stat.isreg | bool %} file must be a regular file.{% endif %}
+    success_msg: "The test passed"


### PR DESCRIPTION
failed_when uses and for list items, and fails only when all conditions are met

The task should fail when any of the conditions are met.
