### PR TITLE
[common] Update the CR tests to mark one as optional

### DIFF
--- a/roles/common/tasks/cr_tests.yml
+++ b/roles/common/tasks/cr_tests.yml
@@ -18,7 +18,7 @@
     condition_type: "{{ item.condition_type if item.condition_type is defined else '' }}"
 
 - name: |
-    {{ "TEST " if condition_type | length >0 }}Verify that the {{ item.kind }} {{ item.name }} CR is {{ condition_type }}
+    {{ 'TEST ' if condition_type | length > 0 }}Verify that the {{ item.kind }} {{ item.name }} CR is {{ condition_type }}
     {{ common_cr_ready_test_id if condition_type | length > 0 }}
   ansible.builtin.command:
     cmd: |
@@ -27,3 +27,6 @@
   changed_when: false
   failed_when:
     - result.stdout != "True"
+  when:
+    - common_cr_ready_test_id is defined
+    - condition_type | length > 0

--- a/roles/common/tasks/cr_tests.yml
+++ b/roles/common/tasks/cr_tests.yml
@@ -9,13 +9,21 @@
   failed_when:
     - result.rc != 0
 
-- name: Verify that a CR is ready
+  # This is added so that the task name will be rendered correctly
+  # If item.condition_type is used and it doesn't exist, then the
+  # literal template text will appear as the task name
+  # e.g. "Verify that the {{ item.kind }} {{ item.name }} CR is {{ item.condition_type }}"
+- name: Set the condition type
+  ansible.builtin.set_fact:
+    condition_type: "{{ item.condition_type if item.condition_type is defined else '' }}"
+
+- name: |
+    {{ "TEST " if condition_type | length >0 }}Verify that the {{ item.kind }} {{ item.name }} CR is {{ condition_type }}
+    {{ common_cr_ready_test_id if condition_type | length > 0 }}
   ansible.builtin.command:
     cmd: |
-      oc get {{ item.kind }} {{ item.name }} -o jsonpath='{.status.conditions[?(@.type=="{{ item.condition_type }}")].status}{"\n"}'
+      oc get {{ item.kind }} {{ item.name }} -o jsonpath='{.status.conditions[?(@.type=="{{ condition_type }}")].status}{"\n"}'
   register: result
   changed_when: false
   failed_when:
     - result.stdout != "True"
-  when:
-    - item.condition_type is defined


### PR DESCRIPTION
Only include the test_id if the condition_type is defined. Set a default for the condition_type so that the task name is rendered correctly in output plugins.

