### PR TITLE
[test_snmp_traps] Add a task to get prom creds at the start of the test

### DIFF
--- a/roles/test_snmp_traps/tasks/main.yml
+++ b/roles/test_snmp_traps/tasks/main.yml
@@ -10,6 +10,16 @@
   register: expected_pods
   changed_when: false
 
+- name: "Set the prom auth"
+  ansible.builtin.include_role:
+    name: client_side_tests
+    tasks_from: get_prom_info.yml
+  vars:
+    prom_auth_method: token
+  when:
+    - prom_auth_string is not defined
+    - prom_url is not defined
+
 - name: "Get the observability strategy and set the observability_api"
   ansible.builtin.include_role:
     name: test_alerts


### PR DESCRIPTION
This ensures that the prom creds are available for the test.
Previously, the tests suites running this would "assume" that the vars were already set.