### PR TITLE
[test_snmp_traps] Add debug after a failure

### DIFF
--- a/roles/test_snmp_traps/tasks/main.yml
+++ b/roles/test_snmp_traps/tasks/main.yml
@@ -69,10 +69,17 @@
     - name: "RHELOSP-144481 Check for snmpTraps logs"
       ansible.builtin.shell:
         cmd: |
-          oc logs -l "app=default-snmp-webhook"  | grep "Sending SNMP trap"
+          oc logs -l "app=default-snmp-webhook" | grep "Sending SNMP trap"
       register: cmd_output
       changed_when: false
       failed_when: "cmd_output.stdout_lines | length == 0"
+
+  rescue:
+    - name: "Get the snmp traps logs"
+      ansible.builtin.shell:
+        cmd: |
+          oc logs -l "app=default-snmp-webhook"
+      changed_when: false
 
   always:
     - name: "Delete the PrometheusRule"


### PR DESCRIPTION
Use rescue to provide additional information when the test fails

This provides additional debug information in the ansible log, making it more convenient to identify the reason for a failure