### PR TITLE
Add pod tests for Completed pods in the OpenStack namespace

### DIFF
--- a/ci/logging_tests_controller.yml
+++ b/ci/logging_tests_controller.yml
@@ -144,6 +144,23 @@
     common_pod_status_str: "Completed"
     common_pod_list:
       - logging-edpm-deployment-openstack-edpm-ipam
+      - bootstrap-edpm-deployment-logging
+      - configure-network-edpm-deployment-logging
+      - configure-os-edpm-deployment-logging
+      - download-cache-edpm-deployment-logging
+      - install-certs-edpm-deployment-logging
+      - install-os-edpm-deployment-logging
+      - libvirt-edpm-deployment-logging
+      - logging-edpm-deployment-logging-openstack-edpm
+      - neutron-metadata-edpm-deployment-logging
+      - nova-custom-edpm-deployment
+      - ovn-edpm-deployment-logging
+      - reboot-os-edpm-deployment-logging
+      - repo-setup-edpm-deployment-logging
+      - run-os-edpm-deployment-logging
+      - ssh-known-hosts-edpm-deployment-logging
+      - telemetry-edpm-deployment-logging
+      - validate-network-edpm-deployment-logging
   tasks:
     - name: "Run pods completed tests"
       ansible.builtin.import_role:

--- a/ci/logging_tests_controller.yml
+++ b/ci/logging_tests_controller.yml
@@ -155,7 +155,6 @@
       - nova-edpm-deployment-openstack-edpm-ipam
       - ovn-edpm-deployment-openstack-edpm-ipam
       - reboot-os-edpm-deployment-openstack-edpm-ipam
-      - repo-setup-edpm-deployment-openstack-edpm-ipam
       - run-os-edpm-deployment-openstack-edpm-ipam
       - ssh-known-hosts-edpm-deployment
       - telemetry-edpm-deployment-openstack-edpm-ipam

--- a/ci/logging_tests_controller.yml
+++ b/ci/logging_tests_controller.yml
@@ -157,7 +157,7 @@
       - reboot-os-edpm-deployment-openstack-edpm-ipam
       - repo-setup-edpm-deployment-openstack-edpm-ipam
       - run-os-edpm-deployment-openstack-edpm-ipam
-      - ssh-known-hosts-edpm-deployment-hr72k
+      - ssh-known-hosts-edpm-deployment
       - telemetry-edpm-deployment-openstack-edpm-ipam
       - validate-network-edpm-deployment-openstack-edpm-ipam
   tasks:

--- a/ci/logging_tests_controller.yml
+++ b/ci/logging_tests_controller.yml
@@ -143,24 +143,23 @@
     common_pod_nspace: openstack
     common_pod_status_str: "Completed"
     common_pod_list:
+      - bootstrap-edpm-deployment-openstack-edpm-ipam
+      - configure-network-edpm-deployment-openstack-edpm-ipam
+      - configure-os-edpm-deployment-openstack-edpm-ipam
+      - download-cache-edpm-deployment-openstack-edpm-ipam
+      - install-certs-edpm-deployment-openstack-edpm-ipam
+      - install-os-edpm-deployment-openstack-edpm-ipam
+      - libvirt-edpm-deployment-openstack-edpm-ipam
       - logging-edpm-deployment-openstack-edpm-ipam
-      - bootstrap-edpm-deployment-logging
-      - configure-network-edpm-deployment-logging
-      - configure-os-edpm-deployment-logging
-      - download-cache-edpm-deployment-logging
-      - install-certs-edpm-deployment-logging
-      - install-os-edpm-deployment-logging
-      - libvirt-edpm-deployment-logging
-      - logging-edpm-deployment-logging-openstack-edpm
-      - neutron-metadata-edpm-deployment-logging
-      - nova-custom-edpm-deployment
-      - ovn-edpm-deployment-logging
-      - reboot-os-edpm-deployment-logging
-      - repo-setup-edpm-deployment-logging
-      - run-os-edpm-deployment-logging
-      - ssh-known-hosts-edpm-deployment-logging
-      - telemetry-edpm-deployment-logging
-      - validate-network-edpm-deployment-logging
+      - neutron-metadata-edpm-deployment-openstack-edpm-ipam
+      - nova-edpm-deployment-openstack-edpm-ipam
+      - ovn-edpm-deployment-openstack-edpm-ipam
+      - reboot-os-edpm-deployment-openstack-edpm-ipam
+      - repo-setup-edpm-deployment-openstack-edpm-ipam
+      - run-os-edpm-deployment-openstack-edpm-ipam
+      - ssh-known-hosts-edpm-deployment-hr72k
+      - telemetry-edpm-deployment-openstack-edpm-ipam
+      - validate-network-edpm-deployment-openstack-edpm-ipam
   tasks:
     - name: "Run pods completed tests"
       ansible.builtin.import_role:


### PR DESCRIPTION
This comes from the original logging job PR: https://github.com/infrawatch/feature-verification-tests/pull/113

The names of the completed pods that are expected to exist have been updated

Depends-On: https://github.com/infrawatch/feature-verification-tests/pull/213
Depends-On: https://github.com/infrawatch/feature-verification-tests/pull/181