### PR TITLE
Move container image patch to post_ctlplane hook

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -10,6 +10,7 @@
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir  }}/scenarios/centos-9/multinode-ci.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-autoscaling.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/vars-functional-test.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/vars-use-master-containers.yml"
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     required-projects: &required_projects

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -113,7 +113,7 @@
             override-checkout: main
             irrelevant-files: *irrelevant_files
         - functional-tests-on-osp18:
-            voting: false
+            voting: true
         - functional-logging-tests-osp18
         - functional-graphing-tests-osp18
         - functional-metric-verification-tests-osp18

--- a/ci/run_autoscaling_osp18.yml
+++ b/ci/run_autoscaling_osp18.yml
@@ -20,26 +20,6 @@
           tags:
             - setup
 
-        - name: Patch the openstackversions to use the master containers for aodh and heat
-          ansible.builtin.shell:
-            cmd: |
-              oc patch openstackversions controlplane --type merge --patch-file ci/patch-openstack-versions.yaml
-            chdir: "{{ fvt_dir }}"
-          when: "{{ patch_openstackversions | bool }}"
-          tags:
-            - setup
-
-        - name: Redeploy the dataplane
-          ansible.builtin.shell:
-            cmd: |
-              oc get osdpd edpm-deployment -oyaml > /tmp/osdpd.yaml
-              oc delete osdpd edpm-deployment
-              sleep 10
-              oc apply -f /tmp/osdpd.yaml
-          when: "{{ patch_openstackversions | bool }}"
-          tags:
-            - setup
-
         - name: Patch observabilityclient into openstackclient
           ansible.builtin.shell:
             cmd: |
@@ -50,50 +30,7 @@
           tags:
             - setup
 
-        - name: Wait until the oscp is resolved the changes to continue
-          ansible.builtin.shell:
-            cmd: |
-              oc get oscp | grep "Setup complete"
-          retries: 24
-          timeout: 5
-          until: output.stdout_lines | length == 1
-          register: output
-          when: "{{ patch_openstackversions | bool }}"
-          tags:
-            - setup
-
-        - name: Wait until the osdpd is redeployed to continue
-          ansible.builtin.shell:
-            cmd: |
-              oc get osdpd | grep "Setup complete"
-          retries: 60
-          delay: 45
-          until: output.stdout_lines | length == 1
-          register: output
-          when: "{{ patch_openstackversions | bool }}"
-          tags:
-            - setup
-
         - name: "Run Telemetry Autoscaling tests"
           ansible.builtin.import_role:
             name: telemetry_autoscaling
           ignore_errors: true
-
-      always:
-        - name: Revert the version update
-          ansible.builtin.shell:
-            cmd: |
-              oc patch  openstackversions controlplane  --type json -p='[{"op": "replace", "path": "/spec/customContainerImages", "value": {} }]'
-          when: "{{ patch_openstackversions | bool }}"
-
-        - name: Redeploy the dataplane
-          ansible.builtin.shell:
-            cmd: |
-              oc get osdpd edpm-deployment -oyaml > /tmp/osdpd.yaml
-              oc delete osdpd edpm-deployment
-              sleep 10
-              oc apply -f /tmp/osdpd.yaml
-          when: "{{ patch_openstackversions | bool }}"
-          tags:
-            - setup
-

--- a/ci/use-master-containers.yml
+++ b/ci/use-master-containers.yml
@@ -1,0 +1,18 @@
+- name: Run telemetry autoscaling tests on osp18
+  hosts:  "{{ cifmw_target_hook_host | default('localhost')  }}"
+  gather_facts: true
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  vars_files:
+    - vars/common.yml
+    - vars/osp18_env.yml
+  tasks:
+    - name: Patch the openstackversions to use the master containers for aodh, heat and ceilometer
+      ansible.builtin.shell:
+        cmd: |
+          oc patch openstackversions controlplane --type merge --patch-file ci/patch-openstack-versions.yaml
+        chdir: "{{ fvt_dir }}"
+      tags:
+        - setup
+

--- a/ci/vars-use-master-containers.yml
+++ b/ci/vars-use-master-containers.yml
@@ -1,0 +1,4 @@
+---
+post_ctlplane_deploy_99_modify_openstackversions:
+  source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/use-master-containers.yml"
+  type: playbook

--- a/roles/telemetry_autoscaling/tasks/test_autoscaling.yml
+++ b/roles/telemetry_autoscaling/tasks/test_autoscaling.yml
@@ -59,6 +59,30 @@
   register: busy_process
   with_items: "{{ vnf_instance_ip.stdout_lines }}"
 
+- name: Show ceilometer_cpu metrics from Prometheus
+  when: metrics_backend == "prometheus"
+  block:
+    - name: Register autoscaling query results
+      shell: |
+        export STACK_ID=$({{ openstack_cmd }} stack show {{ stack_name }} -c id -f value)
+        {{ openstack_cmd }} metric query '(rate(ceilometer_cpu{server_group=~"$STACK_ID"}[150s]))/10000000'
+      ignore_errors: true
+      register: result
+
+    - name: Show the query result
+      ansible.builtin.debug:
+        var: result
+
+    - name: Register ceilometer_cpu metrics
+      shell: |
+        {{ openstack_cmd }} metric show ceilometer_cpu --disable-rbac
+      ignore_errors: true
+      register: result
+
+    - name: Show the ceilometer_cpu metrics
+      ansible.builtin.debug:
+        var: result
+
 - name: |
     TEST Verify cpu high alarm has been triggered
     RHOSO-12660


### PR DESCRIPTION
If we manage to change the openstackversions as needed before the dataplane gets deployed the first time, we don't need to redeploy it later. This could speed up the job by like 30 minutes as well as fix our current issues.