### PR TITLE
[telemetry_logging] Fix failure condition in journalctl

### DIFF
--- a/roles/telemetry_logging/tasks/journal_tests.yml
+++ b/roles/telemetry_logging/tasks/journal_tests.yml
@@ -7,9 +7,20 @@
     cmd: |
       tstamp=$(date -d '30 minute ago' "+%Y-%m-%d %H:%M:%S")
       journalctl -t "{{ item }}" --no-pager -S "${tstamp}"
-  register: journal_wc
+  register: journalctl
   changed_when: false
-  failed_when:  
-    - journal_wc.stdout_lines | length <= 1
-    - '"-- No entries --" in journal_wc.stdout'
-    - journal_wc.stderr_lines | length > 0
+
+- name: |
+    TEST Get journals {{ item }}
+    {{ journal_test_id }}
+  ansible.builtin.assert:
+    that:
+     - 'journalctl.stdout_lines | length > 1'
+     - 'not "-- No entries --" in journalctl.stdout'
+     - 'journalctl.stderr_lines | length == 0'
+    fail_msg: |
+      Journal entry {{ item }} check failed for the following reasons:
+      {%- if journalctl.stdout_lines | length <= 1 %} journalctl output is too short.{% endif %}
+      {%- if  "-- No entries --" in journalctl.stdout %} journalctl output contains "-- No entries --".{% endif %}
+      {%- if journalctl.stdout_lines | length > 0 %} journalctl has an error message.{% endif %}
+    success_msg: "The test passed!"


### PR DESCRIPTION
failed_when and assert use `and` for for list items, and only fails/passes when all conditions are met.

Currently, failed_when is used to trigger a test failure in the journal tests, however, it is implemented incorrectly, since a list is used, and the task will only fail if all conditions are met. This is incorrect, the test should fail if any of the failure conditions are met.

Using assert instead of failed_when means the test will fail if any of the conditions are not met, which is the expected and correct behaviour.

This change switches to using assert, and check for the complementary conditions.
Using assert also allows for some verbose fail messages to aid in debugging.