### PR TITLE
[OSPRH-14451] Change rabbitmq kind to "rabbitmqs"

### DIFF
--- a/roles/telemetry_verify_metrics/tasks/main.yml
+++ b/roles/telemetry_verify_metrics/tasks/main.yml
@@ -15,12 +15,12 @@
       - kind: ceilometer
         name: ceilometer
         condition_type: Ready
-      - kind: rabbitmqclusters
+      - kind: rabbitmqs
         name: rabbitmq
-        condition_type: ReconcileSuccess
-      - kind: rabbitmqclusters
+        condition_type: Ready
+      - kind: rabbitmqs
         name: rabbitmq-cell1
-        condition_type: ReconcileSuccess
+        condition_type: Ready
   tags: precheck
 
 - name: Verify RabbitMQ metrics are being exposed and stored

--- a/roles/telemetry_verify_metrics/tasks/verify_rabbitmq_metrics.yml
+++ b/roles/telemetry_verify_metrics/tasks/verify_rabbitmq_metrics.yml
@@ -9,7 +9,7 @@
 
 - name: Get rabbitmq CR names
   ansible.builtin.shell: |
-    oc get rabbitmq -o custom-columns=NAME:.metadata.name --no-headers
+    oc get rabbitmqs -o custom-columns=NAME:.metadata.name --no-headers
   register: cr_names
   changed_when: false
   failed_when: cr_names.rc >= 1 or cr_names.stdout == ""


### PR DESCRIPTION
The correct kind from FR2 forwards is "rabbitmqs". See https://github.com/infrawatch/feature-verification-tests/pull/232#discussion_r1977072434 for more context.