### PR TITLE
OSPRH-13452: Update functional-tests-on-osp18 to functional-autoscaling-tests-osp18 to match the fvt job name pattern

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,6 +1,6 @@
 ---
 - job:
-    name: functional-tests-on-osp18
+    name: functional-autoscaling-tests-osp18
     parent: telemetry-operator-multinode-autoscaling
     description: |
       Run the autoscaling functional test on osp18+patched version of aodh and heat.
@@ -45,6 +45,14 @@
       - roles/test_sensubility/.*
       - roles/test_snmp_traps/.*
       - roles/test_verify_email/.*
+
+- job:
+    name: functional-tests-on-osp18
+    parent: functional-autoscaling-tests-osp18
+    description: |
+      functional-tests-on-osp18 is an alias of functional-autoscaling-tests-osp18, 
+      temporary added until openstack-k8s-operators/telemetry-operator updates 
+      references of functional-tests-on-osp18 jobs.
 
 - job:
     name: functional-logging-tests-osp18
@@ -114,7 +122,7 @@
         - openstack-k8s-operators-content-provider:
             override-checkout: main
             irrelevant-files: *irrelevant_files
-        - functional-tests-on-osp18:
+        - functional-autoscaling-tests-osp18:
             files:
               - roles/telemetry_autoscaling/.*
               - .zuul.yaml


### PR DESCRIPTION
Why do we need this PR?

The autoscaling job is not called autoscaling upstream.

The `functional-tests-on-osp18` job should be updated to match the pattern for the other  fvt jobs i.e. `functional-autoscaling-tests-osp18`
 
NOTE: This change affects feature-verification-tests as well as telemetry-operator.

Depends-On: https://github.com/infrawatch/feature-verification-tests/pull/252