### PR TITLE
Set default values for *_test_id vars

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,2 +1,14 @@
 ---
 openstack_cmd: "openstack"
+
+common_crd_test_id: "RHOSO-XXXX"
+common_cr_test_id: "RHOSO-XXXX"
+common_cr_ready_test_id: "RHOSO-XXXX"
+common_container_test_id: "RHOSO-XXXX"
+common_endpoint_test_id: "RHOSO-XXXX"
+common_file_test_id: "RHOSO-XXXX"
+common_manifest_test_id: "RHOSO-XXXX"
+common_pod_test_id: "RHOSO-XXXX"
+common_project_test_id: "RHOSO-XXXX"
+common_service_test_id: "RHOSO-XXXX"
+common_subscription_test_id: "RHOSO-XXXX"

--- a/roles/telemetry_logging/defaults/main.yml
+++ b/roles/telemetry_logging/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+journal_test_id: "RHOSO-XXX"


### PR DESCRIPTION
The *test_id var was set for the common and telemetry_logging roles previously, so that the tests would be reported as passed/failed by custom_logger

Since report_result was updated to use XML files to determine failure, the test ID does not need to be set.
This change adds a default value for these vars, so that we can start removing the vars from test configs.