### PR TITLE
OSPRH-13452: Remove the functional-tests-on-osp18 alias

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -49,14 +49,6 @@
       - roles/test_verify_email/.*
 
 - job:
-    name: functional-tests-on-osp18
-    parent: functional-autoscaling-tests-osp18
-    description: |
-      functional-tests-on-osp18 is an alias of functional-autoscaling-tests-osp18, 
-      temporary added until openstack-k8s-operators/telemetry-operator updates 
-      references of functional-tests-on-osp18 jobs.
-
-- job:
     name: functional-logging-tests-osp18
     parent: telemetry-operator-multinode-logging
     description: |


### PR DESCRIPTION
This PR wants to remove the `functional-tests-on-osp18` alias (alias from [functional-autoscaling-tests-osp18](https://github.com/infrawatch/feature-verification-tests/blob/00b0d3996e190d386205d06ffd1f57818f37cf04/.zuul.yaml#L3C11-L3C45) job) because the [openstack-k8s-operators/telemetry-operator](https://github.com/openstack-k8s-operators/telemetry-operator/blob/a2d55f55d5da62bf0b36eea254c44443c56036a1/zuul.d/projects.yaml#L104) project is now using the `functional-autoscaling-tests-osp18` job