### PR TITLE
OSPRH-15988: Remove Enable Graphing at graphing test

### DIFF
--- a/ci/run_graphing_test.yml
+++ b/ci/run_graphing_test.yml
@@ -9,32 +9,7 @@
     - vars/common.yml
   tasks:
     - block:
-        - name: "Enable Graphing"
-          ansible.builtin.shell:
-            cmd: |
-              oc patch oscp/controlplane --type='json' -p '[{"op": "replace", "path": "/spec/telemetry/template/metricStorage/dashboardsEnabled", "value":true}]'
-          register: oscp_change
-          changed_when: false
-
-        - name: Wait until the oscp is resolved the changes to continue
-          ansible.builtin.shell:
-            cmd: |
-              oc get oscp | grep "Setup complete"
-          retries: 24
-          timeout: 5
-          until: output.stdout_lines | length == 1
-          register: output
-
         - name: "Run Graphing Console UI tests"
           ansible.builtin.import_role:
             name: telemetry_graphing
           ignore_errors: true
-
-      always:
-        - name: "Revert the oscp/controlplane change"
-          ansible.builtin.shell:
-            cmd: |
-              oc patch oscp/controlplane --type='json' -p '[{"op": "replace", "path": "/spec/telemetry/template/metricStorage/dashboardsEnabled", "value":false}]'
-
-
-


### PR DESCRIPTION
This PR wants to remove the `dashboardsEnabled` applied in the `Graphing Console UI tests` at [run_graphing_test.yml](https://github.com/MiguelCarpio/feature-verification-tests/blob/master/ci/run_graphing_test.yml) in the [functional-graphing-tests-osp18](https://github.com/infrawatch/feature-verification-tests/blob/00b0d3996e190d386205d06ffd1f57818f37cf04/.zuul.yaml#L108C11-L108C42) job, because dashboards are already enabled in the parent [telemetry-operator-multinode-autoscaling](https://github.com/openstack-k8s-operators/telemetry-operator/blob/a2d55f55d5da62bf0b36eea254c44443c56036a1/zuul.d/projects.yaml#L2) job by the PR   https://github.com/openstack-k8s-operators/telemetry-operator/pull/673

Depends-On: https://github.com/openstack-k8s-operators/telemetry-operator/pull/673