### PR TITLE
[ci] Remove ``files`` from autoscaling job definition

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -49,11 +49,6 @@
       - roles/test_sensubility/.*
       - roles/test_snmp_traps/.*
       - roles/test_verify_email/.*
-    files:
-      - roles/telemetry_verify_metrics/.*
-      - .zuul.yaml
-      - ci/vars-metric-verification-test.yml
-      - ci/report_result.yml
 
 - job:
     name: functional-tests-on-osp18


### PR DESCRIPTION
The `files` attribute on a jobk means that the job will only run if a file from that list is changed.
The autoscaling job definition includes this, and the list of files is specific to the FVT repo. This means that the job will not run in other repos that do not have these matching files.

The files attricute has been removed from the job definition and added to the project definition so that it is only applicable when run in the github-check pipeline for the FVT repo. This allows the job to run in other repos (i.e. openstack-k8s-operators/telemetry-operator) that can configure their own rules for what file changes trigger the jobs to run.