### PR TITLE
[common] Update manifest role and config

### DIFF
--- a/ci/logging_tests_controller.yml
+++ b/ci/logging_tests_controller.yml
@@ -46,9 +46,8 @@
 
     common_manifest_test_id: "RHOSO-12677"
     common_manifest_list:
-      - "loki-operator 2"
-      - "loki-helm-operator 1"
-
+      - ["loki-operator", "2"]
+      - ["loki-helm-operator", "1"]
     common_service_test_id: "RHOSO-12675"
     common_service_nspace: openshift-logging
     common_service_list:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -49,6 +49,8 @@
     - common_manifest_list is defined
   ansible.builtin.include_tasks: "manifest_tests.yml"
   loop: "{{ common_manifest_list }}"
+  loop_control:
+    loop_var: manifest
 
 - name: "Run crd tests"
   when:

--- a/roles/common/tasks/manifest_tests.yml
+++ b/roles/common/tasks/manifest_tests.yml
@@ -1,24 +1,10 @@
 ---
-- name: Get number of packages
-  ansible.builtin.shell:
-    cmd: |
-      echo "{{ item }}" | awk '{print $2;}'
-  register: num_expected
-  changed_when: false
-
-- name: Get package name
-  ansible.builtin.shell:
-    cmd: |
-      echo "{{ item }}" | awk '{print $1;}'
-  register: pack_name
-  changed_when: false
-
 - name: |
-    TEST Get {{ item }} packagemanifest
+    TEST Get {{ manifest[0] }} {{ manifest[1] }} packagemanifest
     {{ common_manifest_test_id }}
   ansible.builtin.shell:
     cmd: |
-      oc get packagemanifests | grep "{{ pack_name.stdout }}" | wc -l
-  register: num_found 
+      oc get packagemanifests | grep "{{ manifest[0] }}"
+  register: num_found
   changed_when: false
-  failed_when: num_expected.stdout != num_found.stdout
+  failed_when: manifest[1] | int != num_found.stdout_lines | length


### PR DESCRIPTION
* Use a list of strings, instead of a space-separated string
* Remove the string separating tasks
* Replace `wc -l` with stdout_lines | length
* Name the loop var