### PR TITLE
[zuul] Add roles/common to the autoscaling and logging jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -121,6 +121,7 @@
         - functional-autoscaling-tests-osp18:
             files:
               - roles/telemetry_autoscaling/.*
+              - roles/common/*
               - .zuul.yaml
               - ci/vars-functional-test.yml
               - ci/run_cloudops_tests_osp18.yml
@@ -134,6 +135,7 @@
             irrelevant-files: *irrelevant_files
             files:
               - roles/telemetry_logging/.*
+              - roles/common/*
               - .zuul.yaml
               - ci/vars-logging-test.yml
               - ci/logging_tests_all.yml


### PR DESCRIPTION
The metrics verification tests in the autoscaling job use the common/ role The logging jobs use the common role.
Changes to roles/common should trigger both of these jobs to run.