### PR TITLE
[GHA] Update the ansible-lint actions used

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,4 +10,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Run ansible-lint
-        uses: ansible-community/ansible-lint-action@main
+        uses: ansible/ansible-lint@v25.6.1
+        with:
+          args: "-c ./.ansible-lint"
+

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.15.0'


### PR DESCRIPTION
ansible-community/ansible-lint-action is no longer available. 
Using ansible/ansible-lint instead.