### PR TITLE
[zuul] Use centos-10 images for master versions

### DIFF
--- a/ci/patch-openstack-versions.yaml
+++ b/ci/patch-openstack-versions.yaml
@@ -1,11 +1,11 @@
 spec:
   customContainerImages:
-    aodhAPIImage: quay.io/podified-master-centos9/openstack-aodh-api:current-podified
-    aodhEvaluatorImage: quay.io/podified-master-centos9/openstack-aodh-evaluator:current-podified
-    aodhListenerImage: quay.io/podified-master-centos9/openstack-aodh-listener:current-podified
-    aodhNotifierImage: quay.io/podified-master-centos9/openstack-aodh-notifier:current-podified
-    ceilometerCentralImage: quay.io/podified-master-centos9/openstack-ceilometer-central:current-podified
-    ceilometerComputeImage: quay.io/podified-master-centos9/openstack-ceilometer-compute:current-podified
-    heatAPIImage: quay.io/podified-master-centos9/openstack-heat-api:current-podified
-    heatCfnapiImage: quay.io/podified-master-centos9/openstack-heat-api-cfn:current-podified
-    heatEngineImage: quay.io/podified-master-centos9/openstack-heat-engine:current-podified
+    aodhAPIImage: quay.rdoproject.org/podified-master-centos10/openstack-aodh-api:current
+    aodhEvaluatorImage: quay.rdoproject.org/podified-master-centos10/openstack-aodh-evaluator:current
+    aodhListenerImage: quay.rdoproject.org/podified-master-centos10/openstack-aodh-listener:current
+    aodhNotifierImage: quay.rdoproject.org/podified-master-centos10/openstack-aodh-notifier:current
+    ceilometerCentralImage: quay.rdoproject.org/podified-master-centos10/openstack-ceilometer-central:current
+    ceilometerComputeImage: quay.rdoproject.org/podified-master-centos10/openstack-ceilometer-compute:current
+    heatAPIImage: quay.rdoproject.org/podified-master-centos10/openstack-heat-api:current
+    heatCfnapiImage: quay.rdoproject.org/podified-master-centos10/openstack-heat-api-cfn:current
+    heatEngineImage: quay.rdoproject.org/podified-master-centos10/openstack-heat-engine:current


### PR DESCRIPTION
The centos9 images are no longer building because of the out-dated python version