### PR TITLE
[ci] Remove the extra copy of XML file from hooks

### DIFF
--- a/.github/workflows/check_plugin.yml
+++ b/.github/workflows/check_plugin.yml
@@ -8,5 +8,5 @@ jobs:
       - uses: actions/checkout@v3
       - run: python3 -m pip install ansible
       - name: Run the test_logger playbook.
-        run: cd ci && rm -rf ~/test_run_result.out && ${HOME}/.local/bin/ansible-playbook -v github/test_logger.yml && diff -s ~/test_run_result.out github/test_logger_expected
+        run: cd ci && rm -rf ~/ci-framework-data/tests/feature-verification-tests/test_run_result.out && ${HOME}/.local/bin/ansible-playbook -v github/test_logger.yml && diff -s ~/ci-framework-data/tests/feature-verification-tests/test_run_result.out github/test_logger_expected
 

--- a/ci/ansible.cfg
+++ b/ci/ansible.cfg
@@ -5,5 +5,5 @@ callback_plugins = ../callback_plugins
 roles_path = ../roles:/usr/share/ansible/roles:/etc/ansible/roles:~/.ansible/roles:../../ci-framework/roles
 
 [custom_logger]
-output_dir = /$HOME
+output_dir = /$HOME/ci-framework-data/tests/feature-verification-tests/
 

--- a/ci/report_result.yml
+++ b/ci/report_result.yml
@@ -11,49 +11,6 @@
         state: directory
         mode: "0755"
 
-- name: "Run the log file collection"
-  hosts:
-    - controller
-    - compute
-  gather_facts: true
-  vars_files:
-    - vars/common.yml
-  tasks:
-    - name: "Find the XML file(s)"
-      ansible.builtin.shell:
-        cmd: |
-          find {{ logs_dir }} -name *.xml
-      register: xml_file_list
-      ignore_errors: true
-
-    - name: "Show the XML files"
-      ansible.builtin.debug:
-        var: xml_file_list.stdout_lines
-      ignore_errors: true
-
-    - name: "Copy the XML files"
-      delegate_to: controller
-      ansible.builtin.copy:
-        remote_src: true
-        src: "{{ item }}"
-        dest: "{{ logs_dir }}/{{ item | basename }} "
-      with_items: "{{ xml_file_list.stdout_lines }}"
-      when: xml_file_list.stdout_lines | length != 0
-
-    - name: "Collect the custom_logger results"
-      delegate_to: controller
-      ansible.builtin.copy:
-        remote_src: true
-        src: "{{ ansible_env.HOME }}/test_run_result.out"
-        dest: "{{ logs_dir }}/test_run_result.out"
-
-    - name: "Collect the results summary"
-      delegate_to: controller
-      ansible.builtin.copy:
-        remote_src: true
-        src: "{{ ansible_env.HOME }}/summary_results.log"
-        dest: "{{ logs_dir }}/summary_result.log"
-
 - name: Check the XML file for failed tasks
   hosts: controller
   gather_facts: true
@@ -71,6 +28,11 @@
          grep -r "<testsuites .*>$" {{ logs_dir }}/
       register: verbose_matches
       ignore_errors: true
+
+    - name: "Fail if there are no XML files"
+      ansible.builtin.fail:
+        msg: "There were no XML files found in {{ logs_dir }}."
+      when: verbose_matches.stdout_lines | length == 0
 
     - name: "Get the number of failed testcases"
       ansible.builtin.set_fact:

--- a/ci/vars-functional-test.yml
+++ b/ci/vars-functional-test.yml
@@ -9,11 +9,6 @@ pre_tests_00_run_functional_test:
   source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/run_cloudops_tests_osp18.yml"
   type: playbook
   config_file: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/ansible.cfg"
-pre_tests_01_copy_results:
-  source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/report_result.yml"
-  type: playbook
-  extra_vars:
-    check_failures: false
 cifmw_run_tests: true
 # redefine this to clear the skipped test
 # this should be done in the parent job IF the openstack versions are updated

--- a/ci/vars-graphing-test.yml
+++ b/ci/vars-graphing-test.yml
@@ -3,11 +3,6 @@ pre_tests_00_run_graphing_test:
   source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/run_graphing_test.yml"
   config_file: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/ansible.cfg"
   type: playbook
-pre_tests_01_copy_results:
-  source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/report_result.yml"
-  type: playbook
-  extra_vars:
-    check_failures: false
 
 cifmw_run_tests: true
 # run only smoke tests

--- a/ci/vars-logging-test.yml
+++ b/ci/vars-logging-test.yml
@@ -4,11 +4,7 @@ pre_tests_00_fvt_logging:
   source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/logging_tests_all.yml"
   config_file: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/ansible.cfg"
   type: playbook
-pre_tests_01_copy_results:
-  source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/report_result.yml"
-  type: playbook
-  extra_vars:
-    check_failures: false
+
 cifmw_run_tests: true
 # enable only the smoketests
 cifmw_test_operator_tempest_include_list: |

--- a/ci/vars-metric-verification-test.yml
+++ b/ci/vars-metric-verification-test.yml
@@ -3,11 +3,6 @@ pre_tests_00_fvt_verify_metrics:
   source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/run_verify_metrics_osp18.yml"
   type: playbook
   config_file: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/ansible.cfg"
-pre_tests_01_copy_results:
-  source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/report_result.yml"
-  type: playbook
-  extra_vars:
-    check_failures: false
 
 cifmw_run_tests: true
 cifmw_test_operator_tempest_include_list: |

--- a/roles/telemetry_graphing/vars/main.yml
+++ b/roles/telemetry_graphing/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 cypress_tests_dir: "{{ ansible_env.HOME }}/cypress-tests" 
 cypress_integration_dir: "{{ cypress_tests_dir }}/cypress/integration"
-screenshots_dir: "{{ ansible_env.HOME }}/ci-framework-data/logs/feature-verification-tests/screenshots"
+screenshots_dir: "{{ ansible_env.HOME }}/ci-framework-data/tests/feature-verification-tests/screenshots"


### PR DESCRIPTION
The logs are output to the expected location, and don't need to be copied twice.