### PR TITLE
[test_autoscaling] Remove the 5 minute pause before checking alarms

### DIFF
--- a/roles/telemetry_autoscaling/tasks/test_autoscaling.yml
+++ b/roles/telemetry_autoscaling/tasks/test_autoscaling.yml
@@ -112,11 +112,6 @@
   register: kill_busy_process
   with_items: "{{ vnf_instance_ip.stdout_lines }}"
 
-  # Does this pause need to be here if there's a repeated check in the following task?
-- name: Test automatic scaling down of instances
-  ansible.builtin.pause:
-    minutes: 5
-
 - name: |
     TEST Verify cpu low alarm has been triggered
   ansible.builtin.shell: |
@@ -125,7 +120,7 @@
         grep -i "cpu_alarm_low" | \
         grep -i "{{ stack_name }}" | \
         awk '{print $2}'
-  retries: 100
+  retries: 160
   delay: 5
   register: result
   until: result.stdout == "alarm"


### PR DESCRIPTION
The tasks that follows does a repeated check for the expected results. The 5 minute pause was rolled into the following task, by increasing the number of retries. Adding in the 5 minutes into this task should mitigate the risk of not having enough time for the alarm to effect to be triggered.