### PR TITLE
OSPCIX-983: [ci][periodic] Replace telemetry-openstack-meta-content-provider-master by openstack-k8s-operators-content-provider

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -163,7 +163,7 @@
     name: infrawatch/feature-verification-tests
     periodic:
       jobs:
-        - telemetry-openstack-meta-content-provider-master:
+        - openstack-k8s-operators-content-provider:
             override-checkout: main
         - functional-periodic-telemetry-with-ceph
     github-check:


### PR DESCRIPTION
**What does this PR do?**
Replace `telemetry-openstack-meta-content-provider-master` by `openstack-k8s-operators-content-provider` in `infrawatch/feature-verification-tests` periodic jobs

**Why do we need it?**
[telemetry-openstack-meta-content-provider-master](https://softwarefactory-project.io/zuul/t/rdoproject.org/builds?job_name=telemetry-openstack-meta-content-provider-master&project=openstack-k8s-operators%2Ftelemetry-operator&project=infrawatch%2Ffeature-verification-tests&skip=0) is permanently failing on periodic pipelines.
 
The following message error comes from the line https://github.com/openstack-k8s-operators/ci-framework/blob/a1b284ccd31d8b9c1cba4e91284289f352195e43/roles/build_openstack_packages/tasks/parse_and_build_pkgs.yml#L16-L18:

```
The task includes an option with an undefined variable. The error was: Unable to look up a name or access an attribute in template string ({{ cifmw_bop_change_list|default([]) + [
{'host': item.change_url | regex_search('(^https?://.*?)/', '\\1') | first, 'project': item.project.name, 'branch': item.branch, 'change': item.change, 'src_dir': item.project.src_dir, 'refspec': '/'.join(['refs', 'changes', item.change[-2:], item.change, item.patchset]) }
] }}).
Make sure your variable name does not contain invalid characters like '-': sequence item 2: expected str instance, AnsibleUndefined found. sequence item 2: expected str instance, AnsibleUndefined found. Unable to look up a name or access an attribute in template string ({{ cifmw_bop_change_list|default([]) + [
{'host': item.change_url | regex_search('(^https?://.*?)/', '\\1') | first, 'project': item.project.name, 'branch': item.branch, 'change': item.change, 'src_dir': item.project.src_dir, 'refspec': '/'.join(['refs', 'changes', item.change[-2:], item.change, item.patchset]) }
] }}).
```
The issue likely stems from using the metacontent provider on a periodic line. The failure is a bug, but the meta content provider is not needed on periodic lines, since the only thing it does differently from the regular content provider job is the role that rebuilds packages on the fly when running the job in an upstream gate or with a depends-on.

We can address this issue by replacing the `telemetry-openstack-meta-content-provider-master` in the periodic line with `openstack-k8s-operators-content-provider`