### PR TITLE
Add disable-rbac to volume metric tests

### DIFF
--- a/roles/telemetry_verify_metrics/tasks/verify_ceilometer_volume_pool_metrics.yml
+++ b/roles/telemetry_verify_metrics/tasks/verify_ceilometer_volume_pool_metrics.yml
@@ -31,7 +31,7 @@
       - ceilometer_volume_provider_pool_capacity_free
       - ceilometer_volume_provider_pool_capacity_total
   ansible.builtin.shell: |
-    {{ openstack_cmd }} metric show {{ item }}
+    {{ openstack_cmd }} metric show --disable-rbac {{ item }}
   register: result
   delay: 30
   retries: 10


### PR DESCRIPTION
The volume metrics don't have a project label, so older versions of the python-observabilityclient aren't able to show the metrics unless we use the --disable-rbac.