### PR TITLE
[ci] Re-add logging vars

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -21,6 +21,7 @@
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-autoscaling.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-logging.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-power-monitoring.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/vars-logging-test.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-autoscaling-tempest.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/vars-functional-test.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/vars-use-master-containers.yml"
@@ -64,33 +65,45 @@
     parent: functional-tests-osp18
     extra-vars: *functional_autoscaling_extra_vars
     description: |
-      functional-tests-on-osp18 is an alias of functional-tests-osp18, 
-      temporary added until openstack-k8s-operators/telemetry-operator updates 
+      functional-tests-on-osp18 is an alias of functional-tests-osp18,
+      temporary added until openstack-k8s-operators/telemetry-operator updates
       references of functional-tests-on-osp18 jobs.
 
 - job:
     name: functional-autoscaling-tests-osp18
     parent: functional-tests-osp18
     description: |
-      functional-autoscaling-tests-osp18 is an alias of functional-tests-osp18, 
-      temporary added until openstack-k8s-operators/telemetry-operator updates 
+      functional-autoscaling-tests-osp18 is an alias of functional-tests-osp18,
+      temporary added until openstack-k8s-operators/telemetry-operator updates
       references of functional-tests-osp18.
 
 - job:
     name: functional-graphing-tests-osp18
     parent: functional-tests-osp18
     description: |
-      functional-graphing-tests-osp18 is an alias of functional-tests-osp18, 
-      temporary added until openstack-k8s-operators/telemetry-operator updates 
+      functional-graphing-tests-osp18 is an alias of functional-tests-osp18,
+      temporary added until openstack-k8s-operators/telemetry-operator updates
       references of functional-tests-osp18.
 
 - job:
     name: functional-logging-tests-osp18
-    parent: functional-tests-osp18
+    dependencies: ["telemetry-openstack-meta-content-provider-master"]
+    parent: telemetry-operator-multinode-logging
     description: |
-      functional-logging-tests-osp18 is an alias of functional-tests-osp18, 
-      temporary added until openstack-k8s-operators/telemetry-operator updates 
-      references of functional-tests-osp18.
+      Run the logging functional tests and tempest smoketests on osp18
+    extra-vars: *functional_autoscaling_extra_vars
+    vars:
+      cifmw_update_containers: false
+      cifmw_extras:
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir  }}/scenarios/centos-9/multinode-ci.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-logging.yml"
+          # Use the tempest config we have for autoscaling tests
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-autoscaling-tempest.yml"
+          # There's an override in here to modify the enabled tests to include only the smoke tests
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/vars-logging-test.yml"
+    roles:
+      - zuul: github.com/openstack-k8s-operators/ci-framework
+    required-projects: *required_projects
 
 - job:
     name: functional-metric-verification-tests-osp18
@@ -115,13 +128,9 @@
     dependencies: ["telemetry-openstack-meta-content-provider-master"]
     description: |
       Deploy OpenStack with Telemetry and Ceph. Run metric-verification with volume pool metric tests
-    extra-vars: 
-      # Override zuul meta content provider provided content_provider_dlrn_md5_hash
-      # var. As returned dlrn md5 hash comes from master release but job is using
-      # antelope content.
-      content_provider_dlrn_md5_hash: ''
-      run_graphing_test: false
+    extra-vars: *functional_autoscaling_extra_vars
     vars:
+      run_graphing_test: false
       patch_observabilityclient: true
       cifmw_update_containers: false
       telemetry_verify_metrics_metric_sources_to_test:
@@ -139,6 +148,7 @@
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir  }}/scenarios/centos-9/multinode-ci.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir  }}/scenarios/centos-9/hci_ceph_backends.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-telemetry-with-ceph.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/vars-logging-test.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-autoscaling-tempest.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/vars-functional-test.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/vars-use-master-containers.yml"
@@ -165,6 +175,17 @@
               - roles/telemetry_logging/.*
               - roles/common/*
               - roles/telemetry_verify_metrics/.*
+        - functional-logging-tests-osp18:
+            irrelevant-files: *irrelevant_files
+            files:
+              - roles/telemetry_logging/.*
+              - roles/common/*
+              - .zuul.yaml
+              - ci/vars-logging-test.yml
+              - ci/logging_tests_all.yml
+              - ci/logging_tests_computes.yml
+              - ci/logging_tests_controller.yml
+              - ci/report_result.yml
               - .zuul.yaml
         - functional-periodic-telemetry-with-ceph:
             files:

--- a/ci/run_functional_tests.yml
+++ b/ci/run_functional_tests.yml
@@ -1,6 +1,3 @@
-- name: Run Logging test
-  ansible.builtin.import_playbook: logging_tests_all.yml
-
 - name: Run Autoscaling test
   ansible.builtin.import_playbook: run_autoscaling_tests.yml
 

--- a/ci/vars-graphing-test.yml
+++ b/ci/vars-graphing-test.yml
@@ -1,0 +1,13 @@
+---
+pre_tests_00_run_graphing_test:
+  source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/run_graphing_test.yml"
+  config_file: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/ansible.cfg"
+  type: playbook
+
+cifmw_run_tests: true
+# run only smoke tests
+cifmw_test_operator_tempest_include_list: |
+  ^tempest.*\[.*\bsmoke\b.*\]
+post_tests_99_collect_results:
+  source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/report_result.yml"
+  type: playbook

--- a/ci/vars-logging-test.yml
+++ b/ci/vars-logging-test.yml
@@ -1,0 +1,15 @@
+---
+# pre_tests or post_tests are also options for when the FVT roles are run
+pre_tests_00_fvt_logging:
+  source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/logging_tests_all.yml"
+  config_file: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/ansible.cfg"
+  type: playbook
+
+cifmw_run_tests: true
+# enable only the smoketests
+cifmw_test_operator_tempest_include_list: |
+  ^tempest.*\[.*\bsmoke\b.*\]
+
+post_tests_99_collect_results:
+  source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/report_result.yml"
+  type: playbook


### PR DESCRIPTION
The logging tests were updated to run unconditionally in PR#275. 

This is a problem when logging is not deployed as the tests fail (which is expected). This change re-adds the previous logging vars file, so that jobs can enable/disable logging tests as before.