### PR TITLE
[telemetry_verify_metrics] Add node exporter filesystem verification …

### DIFF
--- a/roles/telemetry_verify_metrics/tasks/verify_node_exporter_metrics.yml
+++ b/roles/telemetry_verify_metrics/tasks/verify_node_exporter_metrics.yml
@@ -1,3 +1,4 @@
+---
 - name: Verify node exporter scrapeconfigs exist
   ansible.builtin.include_role:
     name: common
@@ -37,3 +38,40 @@
   retries: 10
   changed_when: false
   until: result.rc == 0 and "node_systemd_unit_state" in result.stdout
+
+- name: |
+    TEST Use openstack observabilityclient to verify filesystem metrics from node exporter are stored in prometheus
+  ansible.builtin.shell: |
+    {{ openstack_cmd }} metric show --disable-rbac node_filesystem_size_bytes
+  register: result
+  delay: 30
+  retries: 10
+  changed_when: false
+  until: result.rc == 0 and "node_filesystem_size_bytes" in result.stdout
+
+- name: |
+    Get the filesystem metrics
+  ansible.builtin.command: |
+    {{ openstack_cmd }} metric query --disable-rbac 'node_filesystem_size_bytes{mountpoint="/"}'
+  register: result
+  delay: 30
+  retries: 10
+  changed_when: false
+  until: result.rc == 0
+
+- name: |
+    TEST Verify node exporter reports host filesystem mountpoints instead of container-internal ones
+  ansible.builtin.assert:
+    that:
+      - '"mountpoint" in result.stdout'
+    success_msg: "Node exporter correctly reports host filesystem mountpoints"
+    fail_msg: "Node exporter is not reporting host filesystem mountpoints"
+
+- name: |
+    TEST Verify node exporter filesystem metrics report a real filesystem type instead of overlay
+  ansible.builtin.assert:
+    that:
+      - '"overlay" not in result.stdout'
+      - '"fstype" in result.stdout'
+    success_msg: "Node exporter correctly reports real filesystem types"
+    fail_msg: "Node exporter is reporting overlay filesystem type instead of the real one"


### PR DESCRIPTION
…tests

Verify that node_exporter reports host filesystem metrics instead of container-internal ones, following the --path.rootfs=/rootfs change in edpm-ansible PR #1119.