### PR TITLE
[telemetry_chargeback] Add CloudKitty Scope API verification tests

### DIFF
--- a/roles/telemetry_chargeback/defaults/main.yml
+++ b/roles/telemetry_chargeback/defaults/main.yml
@@ -1,2 +1,6 @@
 ---
 openstack_cmd: "openstack"
+
+# Scope API test variables (OSPRH-23754)
+ck_test_scope_id: "fvt_scope_api_test"
+ck_test_scope_timestamp: "2025-01-01T00:00:00+00:00"

--- a/roles/telemetry_chargeback/defaults/main.yml
+++ b/roles/telemetry_chargeback/defaults/main.yml
@@ -29,6 +29,10 @@ openstackpod: "openstackclient"
 lookback: 6
 limit: 50
 
+# Scope API test variables (OSPRH-23754)
+ck_test_scope_id: "fvt_scope_api_test"
+ck_test_scope_timestamp: "2025-01-01T00:00:00+00:00"
+
 # List of test scenario files to run
 cloudkitty_test_scenarios: ["test_static.yml" , "test_dyn_basic.yml"]
 

--- a/roles/telemetry_chargeback/tasks/main.yml
+++ b/roles/telemetry_chargeback/tasks/main.yml
@@ -2,5 +2,8 @@
 - name: "Validate Chargeback Feature"
   ansible.builtin.include_tasks: "chargeback_tests.yml"
 
+- name: "Validate CloudKitty Scope API (OSPRH-23754)"
+  ansible.builtin.include_tasks: "scope_api_tests.yml"
+
 - name: "Generate Synthetic Data"
   ansible.builtin.include_tasks: "gen_synth_loki_data.yml"

--- a/roles/telemetry_chargeback/tasks/main.yml
+++ b/roles/telemetry_chargeback/tasks/main.yml
@@ -2,6 +2,9 @@
 - name: "Validate Chargeback Feature deployed correctly"
   ansible.builtin.include_tasks: "chargeback_tests.yml"
 
+- name: "Validate CloudKitty Scope API (OSPRH-23754)"
+  ansible.builtin.include_tasks: "scope_api_tests.yml"
+
 - name: "Setup Loki Environment"
   ansible.builtin.include_tasks: "setup_loki_env.yml"
 

--- a/roles/telemetry_chargeback/tasks/scope_api_tests.yml
+++ b/roles/telemetry_chargeback/tasks/scope_api_tests.yml
@@ -1,0 +1,98 @@
+---
+# Verification test for OSPRH-23754: CloudKitty Scope API POST fix
+# The Scope API POST /v2/scope was broken because last_processed_timestamp
+# was not accepted as input, and the active field defaulted to None.
+# CL 970605 fixed this by making last_processed_timestamp a required input
+# parameter and defaulting active to True.
+
+- name: Get OpenStack auth token
+  ansible.builtin.command:
+    cmd: "{{ openstack_cmd }} token issue -f value -c id"
+  register: os_token
+  changed_when: false
+  failed_when: os_token.rc != 0
+
+- name: Get CloudKitty rating endpoint
+  ansible.builtin.shell:
+    cmd: "{{ openstack_cmd }} endpoint list --service rating --interface internal -f value -c URL | head -1"
+  register: ck_endpoint
+  changed_when: false
+  failed_when: ck_endpoint.rc != 0 or ck_endpoint.stdout == ""
+
+- name: Display CloudKitty endpoint
+  ansible.builtin.debug:
+    msg: "CloudKitty endpoint: {{ ck_endpoint.stdout | trim }}"
+
+- name: Create a scope via the Scope API POST
+  ansible.builtin.uri:
+    url: "{{ ck_endpoint.stdout | trim }}/v2/scope"
+    method: POST
+    headers:
+      X-Auth-Token: "{{ os_token.stdout | trim }}"
+      Content-Type: "application/json"
+    body_format: json
+    body:
+      scope_id: "{{ ck_test_scope_id }}"
+      scope_key: "project_id"
+      fetcher: "keystone"
+      collector: "prometheus"
+      last_processed_timestamp: "{{ ck_test_scope_timestamp }}"
+    status_code: [200, 409]
+    return_content: true
+  register: scope_create_response
+
+- name: TEST RHOSO Verify CloudKitty Scope API POST creates a scope (OSPRH-23754)
+  ansible.builtin.assert:
+    that:
+      - scope_create_response.status in [200, 409]
+      - (scope_create_response.status == 409) or
+        (scope_create_response.json.scope_id == ck_test_scope_id and
+         scope_create_response.json.scope_key == "project_id" and
+         scope_create_response.json.fetcher == "keystone" and
+         scope_create_response.json.collector == "prometheus" and
+         scope_create_response.json.active == true and
+         scope_create_response.json.last_processed_timestamp is defined and
+         scope_create_response.json.last_processed_timestamp | length > 0)
+    fail_msg: "FAILED: CloudKitty Scope API POST did not return expected scope data. Response: {{ scope_create_response.json }}"
+    success_msg: >-
+      {{ 'SUCCESS: CloudKitty Scope API POST correctly creates a scope with all fields populated.'
+         if scope_create_response.status == 200 else
+         'SUCCESS: Scope already exists from a previous run (HTTP 409), creation was previously verified.' }}
+
+- name: Retrieve scope via Scope API GET to confirm persistence
+  ansible.builtin.uri:
+    url: "{{ ck_endpoint.stdout | trim }}/v2/scope"
+    method: GET
+    headers:
+      X-Auth-Token: "{{ os_token.stdout | trim }}"
+    return_content: true
+  register: scope_get_response
+
+- name: TEST RHOSO Verify CloudKitty Scope API GET returns the created scope (OSPRH-23754)
+  ansible.builtin.assert:
+    that:
+      - scope_get_response.json is defined
+      - scope_get_response.json | selectattr('scope_id', 'equalto', ck_test_scope_id) | list | length > 0
+    fail_msg: "FAILED: Created scope '{{ ck_test_scope_id }}' not found in Scope API GET response."
+    success_msg: "SUCCESS: Created scope '{{ ck_test_scope_id }}' confirmed via Scope API GET."
+
+- name: POST to Scope API without last_processed_timestamp
+  ansible.builtin.uri:
+    url: "{{ ck_endpoint.stdout | trim }}/v2/scope"
+    method: POST
+    headers:
+      X-Auth-Token: "{{ os_token.stdout | trim }}"
+      Content-Type: "application/json"
+    body_format: json
+    body:
+      scope_id: "fvt_scope_no_timestamp"
+    status_code: 400
+    return_content: true
+  register: scope_create_no_ts
+
+- name: TEST RHOSO Verify CloudKitty Scope API POST rejects request without last_processed_timestamp (OSPRH-23754)
+  ansible.builtin.assert:
+    that:
+      - scope_create_no_ts.status == 400
+    fail_msg: "FAILED: CloudKitty Scope API POST should return 400 when last_processed_timestamp is missing."
+    success_msg: "SUCCESS: CloudKitty Scope API POST correctly rejects request without last_processed_timestamp (HTTP 400)."

--- a/roles/telemetry_chargeback/tasks/scope_api_tests.yml
+++ b/roles/telemetry_chargeback/tasks/scope_api_tests.yml
@@ -1,0 +1,106 @@
+---
+# Verification test for OSPRH-23754: CloudKitty Scope API POST fix
+# The Scope API POST /v2/scope was broken because last_processed_timestamp
+# was not accepted as input, and the active field defaulted to None.
+# CL 970605 fixed this by making last_processed_timestamp a required input
+# parameter and defaulting active to True.
+#
+# API calls use oc exec into the openstackclient pod because the CloudKitty
+# internal endpoint is only resolvable from within the cluster.
+
+- name: Get OpenStack auth token
+  ansible.builtin.command:
+    cmd: "{{ openstack_cmd }} token issue -f value -c id"
+  register: os_token
+  changed_when: false
+  failed_when: os_token.rc != 0
+
+- name: Get CloudKitty rating endpoint
+  ansible.builtin.shell:
+    cmd: "{{ openstack_cmd }} endpoint list --service rating --interface internal -f value -c URL | head -1"
+  register: ck_endpoint
+  changed_when: false
+  failed_when: ck_endpoint.rc != 0 or ck_endpoint.stdout == ""
+
+- name: Display CloudKitty endpoint
+  ansible.builtin.debug:
+    msg: "CloudKitty endpoint: {{ ck_endpoint.stdout | trim }}"
+
+- name: Create a scope via the Scope API POST
+  ansible.builtin.command:
+    cmd: >
+      oc exec -n {{ cloudkitty_namespace }} {{ openstackpod }} --
+      curl -s -o /dev/stdout -w '\n%{http_code}'
+      -X POST "{{ ck_endpoint.stdout | trim }}/v2/scope"
+      -H "X-Auth-Token: {{ os_token.stdout | trim }}"
+      -H "Content-Type: application/json"
+      -d '{"scope_id":"{{ ck_test_scope_id }}","scope_key":"project_id","fetcher":"keystone","collector":"prometheus","last_processed_timestamp":"{{ ck_test_scope_timestamp }}"}'
+  register: scope_create_raw
+  changed_when: false
+  failed_when: false
+
+- name: Parse scope creation response
+  ansible.builtin.set_fact:
+    scope_create_body: "{{ scope_create_raw.stdout_lines[:-1] | join('') }}"
+    scope_create_status: "{{ scope_create_raw.stdout_lines[-1] | int }}"
+
+- name: Display scope creation result
+  ansible.builtin.debug:
+    msg: "Status: {{ scope_create_status }}, Body: {{ scope_create_body }}"
+
+- name: TEST RHOSO Verify CloudKitty Scope API POST creates a scope (OSPRH-23754)
+  ansible.builtin.assert:
+    that:
+      - scope_create_status | int in [200, 409]
+      - (scope_create_status | int == 409) or
+        ((scope_create_body | from_json).scope_id == ck_test_scope_id and
+         (scope_create_body | from_json).scope_key == "project_id" and
+         (scope_create_body | from_json).fetcher == "keystone" and
+         (scope_create_body | from_json).collector == "prometheus" and
+         (scope_create_body | from_json).active == true and
+         (scope_create_body | from_json).last_processed_timestamp is defined and
+         (scope_create_body | from_json).last_processed_timestamp | length > 0)
+    fail_msg: "FAILED: CloudKitty Scope API POST did not return expected scope data. Status: {{ scope_create_status }}, Body: {{ scope_create_body }}"
+    success_msg: >-
+      {{ 'SUCCESS: CloudKitty Scope API POST correctly creates a scope with all fields populated.'
+         if scope_create_status | int == 200 else
+         'SUCCESS: Scope already exists from a previous run (HTTP 409), creation was previously verified.' }}
+
+- name: Retrieve scope via Scope API GET to confirm persistence
+  ansible.builtin.command:
+    cmd: >
+      oc exec -n {{ cloudkitty_namespace }} {{ openstackpod }} --
+      curl -s
+      -X GET "{{ ck_endpoint.stdout | trim }}/v2/scope"
+      -H "X-Auth-Token: {{ os_token.stdout | trim }}"
+  register: scope_get_raw
+  changed_when: false
+  failed_when: scope_get_raw.rc != 0
+
+- name: TEST RHOSO Verify CloudKitty Scope API GET returns the created scope (OSPRH-23754)
+  ansible.builtin.assert:
+    that:
+      - scope_get_raw.stdout | from_json is defined
+      - scope_get_raw.stdout | from_json | selectattr('scope_id', 'equalto', ck_test_scope_id) | list | length > 0
+    fail_msg: "FAILED: Created scope '{{ ck_test_scope_id }}' not found in Scope API GET response."
+    success_msg: "SUCCESS: Created scope '{{ ck_test_scope_id }}' confirmed via Scope API GET."
+
+- name: POST to Scope API without last_processed_timestamp
+  ansible.builtin.command:
+    cmd: >
+      oc exec -n {{ cloudkitty_namespace }} {{ openstackpod }} --
+      curl -s -w '\n%{http_code}' -o /dev/null
+      -X POST "{{ ck_endpoint.stdout | trim }}/v2/scope"
+      -H "X-Auth-Token: {{ os_token.stdout | trim }}"
+      -H "Content-Type: application/json"
+      -d '{"scope_id":"fvt_scope_no_timestamp"}'
+  register: scope_create_no_ts_raw
+  changed_when: false
+  failed_when: false
+
+- name: TEST RHOSO Verify CloudKitty Scope API POST rejects request without last_processed_timestamp (OSPRH-23754)
+  ansible.builtin.assert:
+    that:
+      - scope_create_no_ts_raw.stdout_lines[-1] | int == 400
+    fail_msg: "FAILED: CloudKitty Scope API POST should return 400 when last_processed_timestamp is missing. Got: {{ scope_create_no_ts_raw.stdout_lines[-1] }}"
+    success_msg: "SUCCESS: CloudKitty Scope API POST correctly rejects request without last_processed_timestamp (HTTP 400)."


### PR DESCRIPTION
## Summary
- Adds verification tests for the CloudKitty Scope API POST `/v2/scope` fix (OSPRH-23754, CL 970605)
- Tests that creating a scope with `last_processed_timestamp` succeeds and returns correct data
- Tests that the created scope persists and is retrievable via GET
- Tests that omitting `last_processed_timestamp` correctly returns HTTP 400

## Test plan
- [ ] Run `ansible-lint` on the new task file
- [ ] Execute the chargeback test suite against a deployed environment with the CloudKitty fix applied
- [ ] Verify all three TEST assertions pass in the CI job output