### PR TITLE
[roles/telemetry_chargeback] fix lint errors and set functional testing files for role in CI

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -171,11 +171,11 @@
       - name: github.com/infrawatch/feature-verification-tests
     vars:
       cifmw_extras:
-       - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/scenarios/centos-9/multinode-ci.yml"
-       # Need a config for CK
-       - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-cloudkitty-tempest.yml"
-       - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/vars-use-master-containers.yml"
-       - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/vars-cloudkitty-fvt.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/scenarios/centos-9/multinode-ci.yml"
+        # Need a config for CK
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-cloudkitty-tempest.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/vars-use-master-containers.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/vars-cloudkitty-fvt.yml"
 
 - project:
     name: infrawatch/feature-verification-tests
@@ -189,6 +189,12 @@
         - telemetry-openstack-meta-content-provider-master:
             override-checkout: main
         - functional-chargeback-tests-osp18:
+            files:
+              - roles/telemetry_chargeback/*
+              - ci/vars-cloudkitty-fvt.yml
+              - roles/common/*
+              - ci/report_result.yml
+              - .zuul.yaml
             override-checkout: main
             dependencies:
               - telemetry-openstack-meta-content-provider-master
@@ -200,7 +206,6 @@
             files:
               - roles/telemetry_logging/.*
               - roles/common/*
-              - .zuul.yaml
               - ci/vars-logging-test.yml
               - ci/logging_tests_all.yml
               - ci/logging_tests_computes.yml

--- a/roles/common/tasks/manifest_tests.yml
+++ b/roles/common/tasks/manifest_tests.yml
@@ -2,7 +2,7 @@
 - name: "Check manifest {{ manifest.name }}"
   vars:
     expected_count: "{{ manifest.expected_number | default(1) | int }}"
-    actual_count: "{{ available_manifests | select('search', '^'+manifest.name ) | length }}"
+    actual_count: "{{ available_manifests | select('search', '^' + manifest.name) | length }}"
   block:
     - name: |
         TEST Get {{ manifest.name }} {{ expected_count }} packagemanifest


### PR DESCRIPTION
These changes enable CI jobs to run telemetry_chargeback validation tests when changes are made in relevant files.

Added spacing fix for lint error in manifest_tests.yml file. 