### PR TITLE
[zuul] Fix regex for chargeback and logging tests

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -190,12 +190,11 @@
             override-checkout: main
         - functional-chargeback-tests-osp18:
             files:
-              - roles/telemetry_chargeback/*
-              - ci/vars-cloudkitty-fvt.yml
-              - roles/common/*
-              - ci/report_result.yml
-              - .zuul.yaml
-            override-checkout: main
+              - ^roles/telemetry_chargeback/.*$
+              - ^roles/common/.*$
+              - ^ci/vars-cloudkitty-fvt.yml$
+              - ^ci/report_result.yml$
+              - ^.zuul.yaml$
             dependencies:
               - telemetry-openstack-meta-content-provider-master
         - feature-verification-tests-noop:
@@ -204,19 +203,19 @@
         - functional-logging-tests-osp18:
             irrelevant-files: *irrelevant_files
             files:
-              - roles/telemetry_logging/.*
-              - roles/common/*
-              - ci/vars-logging-test.yml
-              - ci/logging_tests_all.yml
-              - ci/logging_tests_computes.yml
-              - ci/logging_tests_controller.yml
-              - ci/report_result.yml
-              - .zuul.yaml
+              - ^roles/telemetry_logging/.*$
+              - ^roles/common/.*$
+              - ^ci/vars-logging-test.yml$
+              - ^ci/logging_tests_all.yml$
+              - ^ci/logging_tests_computes.yml$
+              - ^ci/logging_tests_controller.yml$
+              - ^ci/report_result.yml$
+              - ^.zuul.yaml$
         - functional-periodic-telemetry-with-ceph:
             files:
               # Run this job for changes to the volume_pool_metrics test changes as this is
               # the only job, where those tests get executed and for changes to zuul.yaml in
               # case the job definition changes.
-              - roles/telemetry_verify_metrics/tasks/verify_ceilometer_volume_pool_metrics.yml
-              - .zuul.yaml
+              - ^roles/telemetry_verify_metrics/tasks/verify_ceilometer_volume_pool_metrics.yml$
+              - ^.zuul.yaml$
 


### PR DESCRIPTION
Enables validation runs of chargeback jobs in branches other than "main"

- Currently, the regex(s) for files are not correct for logging and chargeback jobs  
- Enhance regex to improve robustness of yaml files with usage of "^" and "$" 
- Removed  "override-checkout: main" So, zuul will run PR code  not in "main" branch

Assisted by Claude 