### PR TITLE
Add generic container-image-content-provider job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -2,6 +2,7 @@
 - job:
     name: telemetry-container-image-content-provider
     parent: cifmw-base-minimal
+    nodeset: centos-stream-9-vexxhost
     description: |
       Build sg-core, prometheus-podman-exporter and mysqld-exporter
       container images from the current change and serve them from

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,5 +1,21 @@
 ---
 - job:
+    name: telemetry-container-image-content-provider
+    parent: cifmw-base-minimal
+    abstract: true
+    description: |
+      Build a container image from the current change and serve it from
+      a local registry. Child jobs must set:
+        container_build_src: path to the project source
+        container_build_image_name: image name (e.g. sg-core)
+        container_update_var_name: cifmw_update_containers variable to return
+    required-projects:
+      - name: openstack-k8s-operators/ci-framework
+        override-checkout: main
+    run:
+      - ci/playbooks/container-image-content-provider.yml
+
+- job:
     name: functional-tests-osp18
     dependencies: ["telemetry-openstack-meta-content-provider-master"]
     parent: telemetry-operator-multinode-autoscaling

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -41,7 +41,7 @@
       content_provider_dlrn_md5_hash: ''
     vars:
       patch_observabilityclient: true
-      cifmw_update_containers: false
+      cifmw_update_containers: true
       crc_enable_monitoring: true
       cifmw_extras:
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/scenarios/centos-9/multinode-ci.yml"

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -2,18 +2,29 @@
 - job:
     name: telemetry-container-image-content-provider
     parent: cifmw-base-minimal
-    abstract: true
     description: |
-      Build a container image from the current change and serve it from
-      a local registry. Child jobs must set:
-        container_build_src: path to the project source
-        container_build_image_name: image name (e.g. sg-core)
-        container_update_var_name: cifmw_update_containers variable to return
+      Build sg-core, prometheus-podman-exporter and mysqld-exporter
+      container images from the current change and serve them from
+      a local registry for dependent jobs.
     required-projects:
       - name: openstack-k8s-operators/ci-framework
         override-checkout: main
+      - name: openstack-k8s-operators/sg-core
+      - name: openstack-k8s-operators/prometheus-podman-exporter
+      - name: openstack-k8s-operators/mysqld_exporter
     run:
       - ci/playbooks/container-image-content-provider.yml
+    vars:
+      container_images:
+        - src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/sg-core"
+          name: sg-core
+          update_var: cifmw_update_containers_ceilometersgcoreImage
+        - src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/prometheus-podman-exporter"
+          name: prometheus-podman-exporter
+          update_var: cifmw_update_containers_edpmpodmanexporterImage
+        - src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/mysqld_exporter"
+          name: mysqld-exporter
+          update_var: cifmw_update_containers_ceilometermysqldexporterImage
 
 - job:
     name: functional-tests-osp18

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -22,8 +22,41 @@
           - crc
 
 - job:
+    name: telemetry-container-image-content-provider
+    parent: cifmw-base-minimal
+    description: |
+      Build sg-core, prometheus-podman-exporter and mysqld-exporter
+      container images from the current change and serve them from
+      a local registry for dependent jobs.
+    required-projects:
+      - name: github.com/openstack-k8s-operators/ci-framework
+        override-checkout: main
+      - name: github.com/openstack-k8s-operators/sg-core
+        override-checkout: main
+      - name: github.com/openstack-k8s-operators/prometheus-podman-exporter
+        override-checkout: main
+      - name: github.com/openstack-k8s-operators/mysqld_exporter
+        override-checkout: main
+    run:
+      - ci/playbooks/container-image-content-provider.yml
+    vars:
+      container_images:
+        - src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/sg-core"
+          name: sg-core
+          update_var: cifmw_update_containers_ceilometersgcoreImage
+        - src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/prometheus-podman-exporter"
+          name: prometheus-podman-exporter
+          update_var: cifmw_update_containers_edpmpodmanexporterImage
+        - src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/mysqld_exporter"
+          name: mysqld-exporter
+          update_var: cifmw_update_containers_ceilometermysqldexporterImage
+
+- job:
     name: functional-tests-osp18
-    dependencies: ["telemetry-openstack-meta-content-provider-master"]
+    dependencies: 
+      - name: telemetry-openstack-meta-content-provider-master
+      - name: telemetry-container-image-content-provider
+        soft: true
     parent: telemetry-operator-multinode-autoscaling
     nodeset: telemetry-operator-all-the-features
     description: |
@@ -37,7 +70,10 @@
       content_provider_dlrn_md5_hash: ''
     vars:
       patch_observabilityclient: true
-      cifmw_update_containers: false
+      # Enable update containers so that we have updated containers for mysqld_exporter, prometheus-podman-exporter and sg-core
+      cifmw_update_containers: true
+      # Don't update openstack service containers since we don't have a content provider which would provide these images
+      cifmw_update_containers_openstack: false
       crc_enable_monitoring: true
       cifmw_extras:
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/scenarios/centos-9/multinode-ci.yml"
@@ -65,6 +101,12 @@
       - name: github.com/openstack-k8s-operators/openstack-must-gather
         override-checkout: main
       - name: github.com/openstack-k8s-operators/telemetry-operator
+        override-checkout: main
+      - name: github.com/openstack-k8s-operators/sg-core
+        override-checkout: main
+      - name: github.com/openstack-k8s-operators/prometheus-podman-exporter
+        override-checkout: main
+      - name: github.com/openstack-k8s-operators/mysqld_exporter
         override-checkout: main
     irrelevant-files: &irrelevant_files
       - .github/.*
@@ -191,6 +233,12 @@
       - name: github.com/openstack-k8s-operators/telemetry-operator
         override-checkout: main
       - name: github.com/infrawatch/feature-verification-tests
+      - name: github.com/openstack-k8s-operators/sg-core
+        override-checkout: main
+      - name: github.com/openstack-k8s-operators/prometheus-podman-exporter
+        override-checkout: main
+      - name: github.com/openstack-k8s-operators/mysqld_exporter
+        override-checkout: main
     vars:
       cifmw_extras:
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/scenarios/centos-9/multinode-ci.yml"
@@ -232,6 +280,11 @@
       jobs:
         - telemetry-openstack-meta-content-provider-master:
             override-checkout: main
+        - telemetry-container-image-content-provider:
+            files:
+              - ^ci/playbooks/container-image-build.yml$
+              - ^ci/playbooks/container-image-content-provider.yml$
+              - ^.zuul.yaml$
         - functional-chargeback-tests-osp18:
             files:
               - ^roles/telemetry_chargeback/.*$

--- a/ci/playbooks/container-image-build.yml
+++ b/ci/playbooks/container-image-build.yml
@@ -1,0 +1,28 @@
+---
+- name: "Get commit SHA for {{ container_image.name }}"
+  ansible.builtin.command:
+    cmd: git show-ref --head --hash head
+    chdir: "{{ container_image.src }}"
+  register: _container_sha
+
+- name: "Set image reference for {{ container_image.name }}"
+  ansible.builtin.set_fact:
+    _container_image_url: "{{ cifmw_rp_registry_ip }}:5001/{{ container_image.name }}:{{ _container_sha.stdout | trim }}"
+
+- name: "Build {{ container_image.name }}"
+  ansible.builtin.command:
+    cmd: >-
+      make docker-build
+      IMG={{ _container_image_url }}
+    chdir: "{{ container_image.src }}"
+
+- name: "Push {{ container_image.name }}"
+  ansible.builtin.command:
+    cmd: >-
+      make docker-push
+      IMG={{ _container_image_url }}
+    chdir: "{{ container_image.src }}"
+
+- name: "Record built image {{ container_image.name }}"
+  ansible.builtin.set_fact:
+    _built_images: "{{ _built_images | default([]) + [{'name': container_image.name, 'update_var': container_image.update_var, 'url': _container_image_url}] }}"

--- a/ci/playbooks/container-image-content-provider.yml
+++ b/ci/playbooks/container-image-content-provider.yml
@@ -1,0 +1,51 @@
+---
+- name: Build and serve container image from review
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: true
+  tasks:
+    - name: Discover registry IP
+      ansible.builtin.set_fact:
+        cifmw_rp_registry_ip: "{{ ansible_default_ipv4.address }}"
+
+    - name: Deploy local registry
+      ansible.builtin.include_role:
+        name: registry_deploy
+
+    - name: Get commit SHA
+      ansible.builtin.command:
+        cmd: git show-ref --head --hash head
+      args:
+        chdir: "{{ container_build_src }}"
+      register: _container_sha
+
+    - name: Set image tag
+      ansible.builtin.set_fact:
+        _container_image_tag: "{{ _container_sha.stdout | trim }}"
+
+    - name: Set full image reference
+      ansible.builtin.set_fact:
+        _container_image_url: "{{ cifmw_rp_registry_ip }}:5001/{{ container_build_image_name }}:{{ _container_image_tag }}"
+
+    - name: Build container image
+      ansible.builtin.command:
+        cmd: >-
+          make docker-build
+          IMG={{ _container_image_url }}
+      args:
+        chdir: "{{ container_build_src }}"
+
+    - name: Push container image to local registry
+      ansible.builtin.command:
+        cmd: >-
+          make docker-push
+          IMG={{ _container_image_url }}
+      args:
+        chdir: "{{ container_build_src }}"
+
+    - name: Return image URL for dependent jobs
+      vars:
+        _return_data: >-
+          {{ {'zuul': {'pause': true}}
+             | combine({container_update_var_name: _container_image_url}) }}
+      zuul_return:
+        data: "{{ _return_data }}"

--- a/ci/playbooks/container-image-content-provider.yml
+++ b/ci/playbooks/container-image-content-provider.yml
@@ -14,7 +14,6 @@
     - name: Get commit SHA
       ansible.builtin.command:
         cmd: git show-ref --head --hash head
-      args:
         chdir: "{{ container_build_src }}"
       register: _container_sha
 
@@ -31,7 +30,6 @@
         cmd: >-
           make docker-build
           IMG={{ _container_image_url }}
-      args:
         chdir: "{{ container_build_src }}"
 
     - name: Push container image to local registry
@@ -39,7 +37,6 @@
         cmd: >-
           make docker-push
           IMG={{ _container_image_url }}
-      args:
         chdir: "{{ container_build_src }}"
 
     - name: Return image URL for dependent jobs

--- a/ci/playbooks/container-image-content-provider.yml
+++ b/ci/playbooks/container-image-content-provider.yml
@@ -1,48 +1,25 @@
 ---
-- name: Build and serve container image from review
-  hosts: "{{ cifmw_target_host | default('localhost') }}"
+- name: Build and serve container images from review
+  hosts: "{{ cifmw_target_host | default('controller') }}"
   gather_facts: true
   tasks:
     - name: Discover registry IP
       ansible.builtin.set_fact:
-        cifmw_rp_registry_ip: "{{ ansible_default_ipv4.address }}"
+        cifmw_rp_registry_ip: "{{ ansible_host }}"
 
     - name: Deploy local registry
       ansible.builtin.include_role:
         name: registry_deploy
 
-    - name: Get commit SHA
-      ansible.builtin.command:
-        cmd: git show-ref --head --hash head
-        chdir: "{{ container_build_src }}"
-      register: _container_sha
+    - name: Build and push container images
+      ansible.builtin.include_tasks: container-image-build.yml
+      loop: "{{ container_images }}"
+      loop_control:
+        loop_var: container_image
 
-    - name: Set image tag
-      ansible.builtin.set_fact:
-        _container_image_tag: "{{ _container_sha.stdout | trim }}"
-
-    - name: Set full image reference
-      ansible.builtin.set_fact:
-        _container_image_url: "{{ cifmw_rp_registry_ip }}:5001/{{ container_build_image_name }}:{{ _container_image_tag }}"
-
-    - name: Build container image
-      ansible.builtin.command:
-        cmd: >-
-          make docker-build
-          IMG={{ _container_image_url }}
-        chdir: "{{ container_build_src }}"
-
-    - name: Push container image to local registry
-      ansible.builtin.command:
-        cmd: >-
-          make docker-push
-          IMG={{ _container_image_url }}
-        chdir: "{{ container_build_src }}"
-
-    - name: Return image URL for dependent jobs
-      vars:
-        _return_data: >-
-          {{ {'zuul': {'pause': true}}
-             | combine({container_update_var_name: _container_image_url}) }}
+    - name: Return image URLs and pause for dependent jobs
       zuul_return:
         data: "{{ _return_data }}"
+      vars:
+        _image_overrides: "{{ dict(_built_images | default([]) | map(attribute='update_var') | zip(_built_images | default([]) | map(attribute='url'))) }}"
+        _return_data: "{{ {'zuul': {'pause': true}} | combine(_image_overrides) }}"

--- a/ci/playbooks/container-image-content-provider.yml
+++ b/ci/playbooks/container-image-content-provider.yml
@@ -22,4 +22,5 @@
         data: "{{ _return_data }}"
       vars:
         _image_overrides: "{{ dict(_built_images | default([]) | map(attribute='update_var') | zip(_built_images | default([]) | map(attribute='url'))) }}"
-        _return_data: "{{ {'zuul': {'pause': true}} | combine(_image_overrides) }}"
+        _registry: "{{ cifmw_rp_registry_ip }}:5001"
+        _return_data: "{{ {'zuul': {'pause': true}, 'cifmw_crc_additional_insecure_registries': [_registry], 'cifmw_crc_additional_allowed_registries': [_registry]} | combine(_image_overrides) }}"

--- a/ci/playbooks/container-image-content-provider.yml
+++ b/ci/playbooks/container-image-content-provider.yml
@@ -1,0 +1,31 @@
+---
+- name: Build and serve container images from review
+  hosts: "{{ cifmw_target_host | default('controller') }}"
+  gather_facts: true
+  tasks:
+    # Task copied from https://github.com/openstack-k8s-operators/ci-framework/blob/81ed403edc15e23cc5e4e268e5dffe3891f0b9d5/ci/playbooks/content_provider/pre.yml#L21C1-L28C24
+    - name: Discover an IPv4 for provider job
+      ansible.builtin.set_fact:
+        cifmw_rp_registry_ip: >-
+          {{ hostvars[groups.all[0]].ansible_host if hostvars[groups.all[0]].ansible_host
+          is match("[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+")
+          else hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}
+        cacheable: true
+
+    - name: Deploy local registry
+      ansible.builtin.include_role:
+        name: registry_deploy
+
+    - name: Build and push container images
+      ansible.builtin.include_tasks: container-image-build.yml
+      loop: "{{ container_images }}"
+      loop_control:
+        loop_var: container_image
+
+    - name: Return image URLs and pause for dependent jobs
+      zuul_return:
+        data: "{{ _return_data }}"
+      vars:
+        _image_overrides: "{{ dict(_built_images | default([]) | map(attribute='update_var') | zip(_built_images | default([]) | map(attribute='url'))) }}"
+        _registry: "{{ cifmw_rp_registry_ip }}:5001"
+        _return_data: "{{ {'zuul': {'pause': true}, 'cifmw_crc_additional_insecure_registries': [_registry], 'cifmw_crc_additional_allowed_registries': [_registry]} | combine(_image_overrides) }}"


### PR DESCRIPTION
Add an abstract Zuul job and playbook that builds a container image from the current change and serves it from a local registry. This provides a reusable content-provider pattern for repos like sg-core, prometheus-podman-exporter, and mysqld_exporter that need container image builds as part of the telemetry verification pipeline.

Generated-By: Claude-Code claude-opus-4-6