### PR TITLE
[telemetry_chargeback] Rename vars to follow role naming convention

### DIFF
--- a/roles/telemetry_chargeback/README.md
+++ b/roles/telemetry_chargeback/README.md
@@ -42,8 +42,8 @@ These variables are used internally by the role and typically do not need to be 
 |----------|---------------|-------------|
 | `logs_dir_zuul` | `/home/zuul/ci-framework-data/logs` | Remote directory for log files. |
 | `artifacts_dir_zuul` | `/home/zuul/ci-framework-data/artifacts` | Directory for generated artifacts. |
-| `ck_synth_script` | `{{ role_path }}/files/gen_synth_loki_data.py` | Path to the synthetic data generation script. |
-| `ck_data_template` | `{{ role_path }}/template/loki_data_templ.j2` | Path to the Jinja2 template for Loki data format. |
+| `cloudkitty_synth_script` | `{{ role_path }}/files/gen_synth_loki_data.py` | Path to the synthetic data generation script. |
+| `cloudkitty_data_template` | `{{ role_path }}/templates/loki_data_templ.j2` | Path to the Jinja2 template for Loki data format. |
 | `ck_data_config` | `{{ role_path }}/files/test_static.yml` | Path to the scenario configuration file. |
 | `ck_output_file_local` | `{{ artifacts_dir_zuul }}/loki_synth_data.json` | Local path for generated synthetic data. |
 | `ck_output_file_remote` | `{{ logs_dir_zuul }}/gen_loki_synth_data.log` | Remote destination for synthetic data. |

--- a/roles/telemetry_chargeback/tasks/gen_synth_loki_data.yml
+++ b/roles/telemetry_chargeback/tasks/gen_synth_loki_data.yml
@@ -7,8 +7,8 @@
 - name: TEST Generate Synthetic Data
   ansible.builtin.command:
     cmd: >
-      python3 "{{ ck_synth_script }}"
-      --tmpl "{{ ck_data_template }}"
+      python3 "{{ cloudkitty_synth_script }}"
+      --tmpl "{{ cloudkitty_data_template }}"
       -t "{{ ck_data_config }}"
       -o "{{ ck_output_file_local }}"
   register: script_output

--- a/roles/telemetry_chargeback/vars/main.yml
+++ b/roles/telemetry_chargeback/vars/main.yml
@@ -2,8 +2,19 @@
 logs_dir_zuul: "/home/zuul/ci-framework-data/logs"
 artifacts_dir_zuul: "/home/zuul/ci-framework-data/artifacts"
 
-ck_synth_script: "{{ role_path }}/files/gen_synth_loki_data.py"
-ck_data_template: "{{ role_path }}/templates/loki_data_templ.j2"
+cloudkitty_synth_script: "{{ role_path }}/files/gen_synth_loki_data.py"
+cloudkitty_data_template: "{{ role_path }}/templates/loki_data_templ.j2"
 ck_data_config: "{{ role_path }}/files/test_static.yml"
 ck_output_file_local: "{{ artifacts_dir_zuul }}/loki_synth_data.json"
 ck_output_file_remote: "{{ logs_dir_zuul }}/gen_loki_synth_data.log"
+
+# Scenario and script paths (using role_path)
+cloudkitty_scenario_dir: "{{ role_path }}/files"
+cloudkitty_summary_script: "{{ role_path }}/files/gen_db_summary.py"
+
+# File naming conventions (internal standardization)
+cloudkitty_synth_data_suffix: "-synth_data.json"
+cloudkitty_loki_data_suffix: "-loki_data.json"
+cloudkitty_synth_totals_metrics_suffix: "-synth_metrics_summary.yml"
+cloudkitty_loki_totals_metrics_suffix: "-loki_metrics_summary.yml"
+cloudkitty_loki_totals_suffix: "-rating.yml"


### PR DESCRIPTION
Rename variables from ck_* prefix to cloudkitty_* prefix to follow where appropriate.  
- Ansible best practice: <role_name>_<var_name>
- Update README file with new var names.

Variable renames:
- ck_synth_script to cloudkitty_synth_script
- ck_data_template to cloudkitty_data_template

Other variables with ck_* prefix will be deprecated in subsequent pull requests 