### PR TITLE
Use larger CRC node (4xl) for functional-tests-osp18

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,8 +1,31 @@
 ---
+- nodeset:
+    name: telemetry-operator-all-the-features
+    # Use a larger crc with the nodeset for the parent job to account
+    # for openshift monitoring and autoscaling features being deployed.
+    # Original nodeset: centos-9-medium-centos-9-crc-cloud-ocp-4-20-1-3xl
+    # Defined in: openstack-k8s-operators/ci-framework
+    #   Job: cifmw-podified-multinode-edpm-base-crc
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: crc-cloud-ocp-4-20-1-4xl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+      - name: ocps
+        nodes:
+          - crc
+
 - job:
     name: functional-tests-osp18
     dependencies: ["telemetry-openstack-meta-content-provider-master"]
     parent: telemetry-operator-multinode-autoscaling
+    nodeset: telemetry-operator-all-the-features
     description: |
       Run autoscaling functional tests, tempest tests, metrics
       functional tests, graphing functional tests and logging functional tests on

--- a/roles/telemetry_graphing/files/dashboard-openstack-cloud.js.j2
+++ b/roles/telemetry_graphing/files/dashboard-openstack-cloud.js.j2
@@ -39,7 +39,7 @@ describe('OpenShift Console Dashboard Test', () => {
 
     dashboards.forEach(({ url, screenshot }) => {
       cy.visit(`https://console-openshift-console.apps-crc.testing/monitoring/dashboards${url}`);
-      cy.get('div[data-test-id="dashboard"]', { timeout: 20000 }).find('[data-test-id^="panel-"]')
+      cy.get('div[data-test-id="dashboard"], section[data-test-id="dashboard"]', { timeout: 20000 }).find('[data-test-id^="panel-"]')
       cy.wait(1000);
       cy.screenshot(screenshot);
     });


### PR DESCRIPTION
The functional-tests-osp18 job has been consistently failing with autoscaling test failures and tempest setUpClass failures. The job deploys more services (autoscaling with Aodh/Heat, logging, power monitoring with Kepler) compared to the passing functional-chargeback job which only focuses on CloudKitty.

This patch increases the CRC node size from 3xl to 4xl to provide more resources for the complex autoscaling deployment.

Analysis showed that functional-chargeback-tests-osp18 (simpler deployment) passes consistently on the same nodeset, suggesting the failures are related to resource constraints rather than infrastructure issues.

Tools used: zuul-mcp https://github.com/imatza/zuul-mcp

Generated-By: Claude Sonnet 4.5