### PR TITLE
Remove noop parent

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -138,7 +138,6 @@
 
 - job:
     name: feature-verification-tests-noop
-    parent: noop
     description: |
       A job that always passes. Runs when there's a change to jobs that don't
       need full zuul to run but still need to report a pass.
@@ -241,4 +240,3 @@
               # case the job definition changes.
               - ^roles/telemetry_verify_metrics/tasks/verify_ceilometer_volume_pool_metrics.yml$
               - ^.zuul.yaml$
-


### PR DESCRIPTION
This change fixes the following zuul config-error:

  "noop" is final and can not act as a parent