### PR TITLE
Use base zuul noop job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -137,15 +137,6 @@
       functional tests on osp18+patched versions of adoh and heat.
 
 - job:
-    name: feature-verification-tests-noop
-    parent: noop
-    description: |
-      A job that always passes. Runs when there's a change to jobs that don't
-      need full zuul to run but still need to report a pass.
-    run:
-      - ci/noop.yml
-
-- job:
     name: functional-periodic-telemetry-with-ceph
     parent: podified-multinode-hci-deployment-crc-1comp-backends
     dependencies: ["telemetry-openstack-meta-content-provider-master"]
@@ -220,7 +211,7 @@
               - ^.zuul.yaml$
             dependencies:
               - telemetry-openstack-meta-content-provider-master
-        - feature-verification-tests-noop:
+        - noop:
             files: *irrelevant_files
         - functional-tests-osp18
         - functional-logging-tests-osp18:


### PR DESCRIPTION
Use a noop job from zuul instead of a custom variant. Apparently the noop job was made final recently, so we can't inherit from it anymore.

See zuul/model.py in https://review.opendev.org/c/zuul/zuul/+/986659