### PR TITLE
Remove noop parent and use stronger node for ceph job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -148,6 +148,7 @@
     name: functional-periodic-telemetry-with-ceph
     parent: podified-multinode-hci-deployment-crc-1comp-backends
     dependencies: ["telemetry-openstack-meta-content-provider-master"]
+    nodeset: telemetry-operator-all-the-features
     description: |
       Deploy OpenStack with Telemetry and Ceph. Run metric-verification with volume pool metric tests
     extra-vars: *functional_autoscaling_extra_vars

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -138,7 +138,6 @@
 
 - job:
     name: feature-verification-tests-noop
-    parent: noop
     description: |
       A job that always passes. Runs when there's a change to jobs that don't
       need full zuul to run but still need to report a pass.
@@ -241,4 +240,3 @@
               # case the job definition changes.
               - ^roles/telemetry_verify_metrics/tasks/verify_ceilometer_volume_pool_metrics.yml$
               - ^.zuul.yaml$
-


### PR DESCRIPTION
- Remove noop job as a parent of the feature-verification-tests-noop job. The internal zuul noop job has been recently made final, so we can't inherit from it anymore.
- Use the stronger telemetry-operator-all-the-features nodeset for the ceph job, since it's currently failing with weaker nodes due to lack of resources.