### PR TITLE
Fix RHELOSP-176036 and RHELOSP-176038 sensubility health status tests

### DIFF
--- a/roles/client_side_tests/tasks/get_prom_info.yml
+++ b/roles/client_side_tests/tasks/get_prom_info.yml
@@ -35,7 +35,7 @@
     - name: "Generate an access token for prometheus"
       ansible.builtin.shell:
         cmd: |
-          oc create token stf-prometheus-reader
+          oc create token stf-prometheus-reader --duration=24h
       register: prom_token_out
       changed_when: false
 

--- a/roles/test_sensubility/tasks/test_health_status.yml
+++ b/roles/test_sensubility/tasks/test_health_status.yml
@@ -1,30 +1,37 @@
-  #In this test we choose one container (logrotate_crond),checking that it is running 
-  #and then stopping the container and starting it again and checking that its health status changes accordingly.
+# In this test we choose one container (rsyslog),checking that it is running
+# and then stopping the container and starting it again and checking that its health status changes accordingly.
+#
+# NOTE(dpawlik): Earlier we were using logrotate_crond service to verify the
+# functionality. That has been changed to rsyslog, because in the
+# /config-scripts/collectd_check_health.py script that is running in collectd
+# container, in the SKIP_LIST, the regex contains: '.*_cron' which "fit"
+# the name 'logrotate_crond'. The regex should be '.*_cron$', then the
+# tests would pass.
 
-- name: RHELOSP-176011 Check that logrotate_crond container is running on ceph-0
+- name: RHELOSP-176011 Check that rsyslog container is running on ceph-0
   delegate_to: ceph-0
   become: true
   delegate_facts: True
   ansible.builtin.shell:
     cmd: |
-      {{ container_bin }} ps | grep logrotate_crond
+      {{ container_bin }} ps | grep rsyslog
   register: container_nodes
   changed_when: false
   failed_when: container_nodes.stdout_lines|length != 1
 
 
-- name: RHELOSP-176012 Stop logrotate_crond container on ceph-0
+- name: RHELOSP-176012 Stop rsyslog container on ceph-0
   ansible.builtin.shell:
     cmd: |
-       systemctl stop tripleo_logrotate_crond
+       systemctl stop tripleo_rsyslog
   delegate_to: ceph-0
   become: true
   register: output
   changed_when: false
 
-- name: RHELOSP-176037 Check that logrotate_crond container has stopped
+- name: RHELOSP-176037 Check that rsyslog container has stopped
   ansible.builtin.shell: |
-    {{ container_bin }} ps | grep logrotate_crond 
+    {{ container_bin }} ps | grep rsyslog
   delegate_to: ceph-0
   become: true
   register: container_nodes
@@ -34,38 +41,39 @@
 - name: Check what metrics are available to prometheus that relate to sensubility
   ansible.builtin.shell:
     cmd: |
-      curl -k {{ prom_auth_string }} -g https://${prom_url}/api/v1/label/__name__/values | jq | grep sensubility
+      curl -k {{ prom_auth_string }} -g https://{{ prom_url }}/api/v1/label/__name__/values | jq | grep sensubility
   changed_when: false
 
 - name: RHELOSP-176036 Check that health status of container changed to 0
-  ansible.builtin.shell:
-    cmd: /usr/bin/curl -k {{ prom_auth_string }} -g https://{{ prom_url }}/api/v1/query? --data-urlencode 'query=last_over_time(sensubility_container_health_status{process="logrotate_crond",host="ceph-0.redhat.local"}[10m])' | grep -oP '(?<="value":).*' | awk -F, '{ print $2 }' | grep -o '[0-9]\+' | grep 0
+  ansible.builtin.shell: >
+    /usr/bin/curl
+    -k {{ prom_auth_string }}
+    -g https://{{ prom_url }}/api/v1/query?
+    --data-urlencode 'query=last_over_time(sensubility_container_health_status{process="rsyslog",host="ceph-0.redhat.local"}[10m])' | grep -oP '(?<="value":).*' | awk -F, '{ print $2 }' | grep -o '[0-9]\+' | grep 0
   register: output
   changed_when: false
   retries: 60
   delay: 10
   until: "output.stdout_lines | length == 1"
 
-- name: RHELOSP-176035 Start logrotate_crond container
+- name: RHELOSP-176035 Start rsyslog container
   ansible.builtin.shell:
     cmd: |
-       systemctl start tripleo_logrotate_crond
+       systemctl start tripleo_rsyslog
   delegate_to: ceph-0
   become: true
   register: output
   changed_when: false
-
 
 - name: RHELOSP-176038 Check that health status of container changed to 1
   ansible.builtin.shell:
     cmd: >-
       /usr/bin/curl -k {{ prom_auth_string }} \
         -g https://{{ prom_url }}/api/v1/query? \
-        --data-urlencode 'query=last_over_time(sensubility_container_health_status{process="logrotate_crond",host="ceph-0.redhat.local"}[10m])' \
+        --data-urlencode 'query=last_over_time(sensubility_container_health_status{process="rsyslog",host="ceph-0.redhat.local"}[10m])' \
         | grep -oP '(?<="value":).*' | awk -F, '{ print $2 }' |  grep -o '[0-9]\+' | grep 1
   register: output
   changed_when: false
   retries: 60
   delay: 10
   until: "output.stdout_lines | length == 1"
-


### PR DESCRIPTION
Both tests were failing because the script that is running inside the collectd container (collectd_check_health.py; check /etc/collectd-sensubility.conf config file in the collectd container) contains `.*_cron` in SKIP_LIST names that will ignore for checking current status. Instead of fixing the regex `(.*_cron$)`, let's use another container name, that would not affect later tests.