### PR TITLE
[telemetry_chargeback] add the ability to pass test scenario names via extra-vars

### DIFF
--- a/roles/telemetry_chargeback/README.md
+++ b/roles/telemetry_chargeback/README.md
@@ -51,6 +51,7 @@ Role Variables
 | `openstackpod` | `"openstackclient"` | OpenStack client pod name for exec/cp operations |
 | `lookback` | `6` | Days to look back for Loki query time range |
 | `limit` | `50` | Limit for Loki query results |
+| `cloudkitty_test_scenarios` | `["test_static.yml", "test_dyn_basic.yml"]` | List of test scenario files to run (can be overridden via extra-vars) |
 
 How It Works
 ------------
@@ -67,8 +68,9 @@ The role executes the following workflow:
    - Retrieves certificates from secrets/configmaps
    - Configures Loki push/query URLs
 
-3. **Test Scenario Discovery**
-   - Automatically finds all `test_*.yml` files in `files/` directory
+3. **Test Scenario Selection**
+   - Uses scenarios defined in `cloudkitty_test_scenarios` variable
+   - Can be overridden via extra-vars to run specific scenarios
 
 4. **Scenario Execution Loop** (for each discovered scenario)
    - Generates synthetic Loki log data (`gen_synth_loki_data.py`)
@@ -204,7 +206,7 @@ When `--debug` is enabled, the script writes a `<stem>_diff.txt` file containing
 Scenario Configuration
 ----------------------
 
-Test scenarios are defined in YAML files located in the `files/` directory. Any file matching the pattern `test_*.yml` will be automatically discovered and executed.
+Test scenarios are defined in YAML files located in the `files/` directory. The scenarios to run are specified by the `cloudkitty_test_scenarios` variable.
 
 ### Available Scenarios
 
@@ -265,7 +267,7 @@ This role has no direct hard dependencies on other Ansible roles.
 Example Playbook
 ----------------
 
-**Basic usage (auto-discover scenarios):**
+**Basic usage (runs default scenarios):**
 ```yaml
 - name: "Run chargeback tests"
   hosts: controllers
@@ -293,6 +295,27 @@ Example Playbook
         lookback: 10
 ```
 
+**Run specific test scenarios:**
+```yaml
+- name: "Run chargeback tests with specific scenarios"
+  hosts: controllers
+  gather_facts: false
+
+  tasks:
+    - name: "Run chargeback validation with custom scenarios"
+      ansible.builtin.import_role:
+        name: telemetry_chargeback
+      vars:
+        cloudkitty_test_scenarios:
+          - "test_static.yml"
+```
+
+**Run custom scenarios via extra-vars:**
+```bash
+ansible-playbook playbook.yml \
+  -e '{"cloudkitty_test_scenarios": ["test_static.yml", "test_custom.yml"]}'
+```
+
 License
 -------
 
@@ -303,5 +326,5 @@ Author Information
 
 Alex Yefimov, Red Hat
 
-**Project:** RHOSO (Red Hat OpenStack Services on OpenShift)  
+**Project:** RHOSO (Red Hat OpenStack Services on OpenShift)
 **Component:** Telemetry - CloudKitty Chargeback

--- a/roles/telemetry_chargeback/README.md
+++ b/roles/telemetry_chargeback/README.md
@@ -51,7 +51,7 @@ Role Variables
 | `openstackpod` | `"openstackclient"` | OpenStack client pod name for exec/cp operations |
 | `lookback` | `6` | Days to look back for Loki query time range |
 | `limit` | `50` | Limit for Loki query results |
-| `cloudkitty_test_scenarios` | `["test_static.yml", "test_dyn_basic.yml"]` | List of test scenario files to run (can be overridden via extra-vars) |
+| `cloudkitty_test_scenarios` | `["test_static.yml", "test_dyn_basic.yml"]` | List of test scenario files to run|
 
 How It Works
 ------------
@@ -70,7 +70,6 @@ The role executes the following workflow:
 
 3. **Test Scenario Selection**
    - Uses scenarios defined in `cloudkitty_test_scenarios` variable
-   - Can be overridden via extra-vars to run specific scenarios
 
 4. **Scenario Execution Loop** (for each discovered scenario)
    - Generates synthetic Loki log data (`gen_synth_loki_data.py`)

--- a/roles/telemetry_chargeback/defaults/main.yml
+++ b/roles/telemetry_chargeback/defaults/main.yml
@@ -6,7 +6,6 @@ openstack_cmd: "openstack"
 cloudkitty_debug: false
 cloudkitty_debug_dir: "{{ (cloudkitty_debug | bool) | ternary(artifacts_dir_zuul + '/debug_ck_db', '') }}"
 
-# Directory paths
 logs_dir_zuul: "{{ cifmw_basedir }}/logs"
 artifacts_dir_zuul: "{{ cifmw_basedir }}/artifacts"
 cert_dir: "{{ cifmw_basedir }}/ck-certs"
@@ -28,3 +27,6 @@ openstackpod: "openstackclient"
 # Time window settings
 lookback: 6
 limit: 50
+
+# List of test scenario files to run
+cloudkitty_test_scenarios: []

--- a/roles/telemetry_chargeback/defaults/main.yml
+++ b/roles/telemetry_chargeback/defaults/main.yml
@@ -29,4 +29,4 @@ lookback: 6
 limit: 50
 
 # List of test scenario files to run
-cloudkitty_test_scenarios: []
+cloudkitty_test_scenarios: ["test_static.yml"]

--- a/roles/telemetry_chargeback/defaults/main.yml
+++ b/roles/telemetry_chargeback/defaults/main.yml
@@ -29,4 +29,4 @@ lookback: 6
 limit: 50
 
 # List of test scenario files to run
-cloudkitty_test_scenarios: ["test_static.yml"]
+cloudkitty_test_scenarios: []

--- a/roles/telemetry_chargeback/defaults/main.yml
+++ b/roles/telemetry_chargeback/defaults/main.yml
@@ -6,6 +6,7 @@ openstack_cmd: "openstack"
 cloudkitty_debug: false
 cloudkitty_debug_dir: "{{ (cloudkitty_debug | bool) | ternary(artifacts_dir_zuul + '/debug_ck_db', '') }}"
 
+# Directory paths
 logs_dir_zuul: "{{ cifmw_basedir }}/logs"
 artifacts_dir_zuul: "{{ cifmw_basedir }}/artifacts"
 cert_dir: "{{ cifmw_basedir }}/ck-certs"
@@ -29,4 +30,4 @@ lookback: 6
 limit: 50
 
 # List of test scenario files to run
-cloudkitty_test_scenarios: []
+cloudkitty_test_scenarios: ["test_static.yml" , "test_dyn_basic.yml"]

--- a/roles/telemetry_chargeback/tasks/main.yml
+++ b/roles/telemetry_chargeback/tasks/main.yml
@@ -15,19 +15,23 @@
   ansible.builtin.set_fact:
     found_files: "{{ found_files_raw.files | map(attribute='path') | map('basename') | map('regex_replace', '\\.yml$', '') | list }}"
 
+- name: "Determine which scenarios to run"
+  ansible.builtin.set_fact:
+    scenarios_to_run: "{{ cloudkitty_test_scenarios if cloudkitty_test_scenarios | length > 0 else found_files }}"
+
 - name: "Run scenario file through workflow"
   block:
     - name: "Process and Loop if files exist"
       ansible.builtin.include_tasks: run_test_scenarios.yml
-      loop: "{{ found_files }}"
+      loop: "{{ scenarios_to_run }}"
       loop_control:
         loop_var: scenario_name
-      when: found_files | length > 0
+      when: scenarios_to_run | length > 0
 
   rescue:
     - name: "Log failure"
-      ansible.builtin.debug:
-        msg: "Running test scenarios loop failed."
+      ansible.builtin.fail:
+        msg: "Running test scenarios loop failed. Please check logs"
 
   always:
     - name: "Cleanup after job run"

--- a/roles/telemetry_chargeback/tasks/main.yml
+++ b/roles/telemetry_chargeback/tasks/main.yml
@@ -5,20 +5,9 @@
 - name: "Setup Loki Environment"
   ansible.builtin.include_tasks: "setup_loki_env.yml"
 
-- name: "Find test files"
-  ansible.builtin.find:
-    paths: "{{ cloudkitty_scenario_dir }}"
-    patterns: "test_*.yml"
-  register: found_files_raw
-
-- name: "Extract only the filenames into a clean list"
-  ansible.builtin.set_fact:
-    found_files: "{{ found_files_raw.files | map(attribute='path') | map('basename') | list }}"
-
 - name: "Determine which scenarios to run"
   ansible.builtin.set_fact:
-    scenarios_to_run: "{{ (cloudkitty_test_scenarios if cloudkitty_test_scenarios | length > 0 else found_files) | map('regex_replace', '\\.yml$', '') | list }}"
-
+    scenarios_to_run: "{{ cloudkitty_test_scenarios | map('regex_replace', '\\.yml$', '') | list }}"
 
 - name: "Run scenario file through workflow"
   block:

--- a/roles/telemetry_chargeback/tasks/main.yml
+++ b/roles/telemetry_chargeback/tasks/main.yml
@@ -13,16 +13,17 @@
 
 - name: "Extract only the filenames into a clean list"
   ansible.builtin.set_fact:
-    found_files: "{{ found_files_raw.files | map(attribute='path') | map('basename') | map('regex_replace', '\\.yml$', '') | list }}"
+    found_files: "{{ found_files_raw.files | map(attribute='path') | map('basename') | list }}"
 
 - name: "Determine which scenarios to run"
   ansible.builtin.set_fact:
-    scenarios_to_run: "{{ cloudkitty_test_scenarios if cloudkitty_test_scenarios | length > 0 else found_files }}"
+    scenarios_to_run: "{{ (cloudkitty_test_scenarios if cloudkitty_test_scenarios | length > 0 else found_files) | map('regex_replace', '\\.yml$', '') | list }}"
+
 
 - name: "Run scenario file through workflow"
   block:
     - name: "Process and Loop if files exist"
-      ansible.builtin.include_tasks: run_test_scenarios.yml
+      ansible.builtin.include_tasks: "run_test_scenarios.yml"
       loop: "{{ scenarios_to_run }}"
       loop_control:
         loop_var: scenario_name
@@ -35,4 +36,4 @@
 
   always:
     - name: "Cleanup after job run"
-      ansible.builtin.include_tasks: cleanup_ck.yml
+      ansible.builtin.include_tasks: "cleanup_ck.yml"

--- a/roles/telemetry_chargeback/tasks/main.yml
+++ b/roles/telemetry_chargeback/tasks/main.yml
@@ -5,11 +5,12 @@
 - name: "Setup Loki Environment"
   ansible.builtin.include_tasks: "setup_loki_env.yml"
 
-- name: "Determine which scenarios to run"
+# Scenario name is file name without extension
+- name: "Generate clean list of scenario names"
   ansible.builtin.set_fact:
     scenarios_to_run: "{{ cloudkitty_test_scenarios | map('regex_replace', '\\.yml$', '') | list }}"
 
-- name: "Run scenario file through workflow"
+- name: "Run scenarios through workflow"
   block:
     - name: "Process and Loop if files exist"
       ansible.builtin.include_tasks: "run_test_scenarios.yml"


### PR DESCRIPTION
Implemented the ability to pass test scenario names via extra-vars
- Add cloudkitty_test_scenarios variable which will allow for extra-vars override
- Set default value for cloudkitty_test_scenarios list (Default test scenarios)
- Removed self discovery of test Scenarios from main.yml
- README. md updated only with test scenario list changes. Other doc changes will be added later. 

Authored-by: @myadla
Co-authored-by: @ayefimov-1
AI Assisted by: Claude
