### PR TITLE
Adding audit logging role and functional tests

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -200,6 +200,28 @@
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/vars-use-master-containers.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/vars-cloudkitty-fvt.yml"
 
+- job:
+    name: functional-audit-logging-tests-osp18
+    dependencies: ["telemetry-openstack-meta-content-provider-master"]
+    parent: telemetry-operator-multinode-logging
+    description: |
+      Run audit logging functional tests on osp18
+    extra-vars: *functional_autoscaling_extra_vars
+    irrelevant-files: []
+    roles:
+      - zuul: github.com/openstack-k8s-operators/ci-framework
+      - zuul: github.com/infrawatch/feature-verification-tests
+    required-projects: *required_projects
+    vars:
+      cifmw_update_containers: false
+      cifmw_extras:
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/scenarios/centos-9/multinode-ci.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-logging.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-autoscaling-tempest.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/vars-use-master-containers.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-audit-logging.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/vars-audit-logging-fvt.yml"
+
 - project:
     name: infrawatch/feature-verification-tests
     periodic:
@@ -216,6 +238,16 @@
               - ^roles/telemetry_chargeback/.*$
               - ^roles/common/.*$
               - ^ci/vars-cloudkitty-fvt.yml$
+              - ^ci/report_result.yml$
+              - ^.zuul.yaml$
+            dependencies:
+              - telemetry-openstack-meta-content-provider-master
+        - functional-audit-logging-tests-osp18:
+            files:
+              - ^roles/telemetry_audit_logging/.*$
+              - ^roles/common/.*$
+              - ^ci/vars-audit-logging-fvt.yml$
+              - ^ci/run_audit_logging_tests.yml$
               - ^ci/report_result.yml$
               - ^.zuul.yaml$
             dependencies:

--- a/ci/run_audit_logging_tests.yml
+++ b/ci/run_audit_logging_tests.yml
@@ -1,0 +1,51 @@
+---
+- name: "Verify all the applicable projects, pods & services for audit logging"
+  hosts: "{{ cifmw_target_hook_host | default('localhost')  }}"
+  gather_facts: true
+  ignore_errors: true
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  vars_files:
+    - vars/common.yml
+    - vars/osp18_env.yml
+  vars:
+    common_pod_status_str: "Running"
+    common_pod_nspace: openshift-logging
+    common_pod_list:
+      - logging-loki-audit-distributor
+      # pod tests expect only one instance of a pod, there are two of this one
+      #- logging-loki-audit-gateway
+      - logging-loki-audit-index-gateway
+      - logging-loki-audit-ingester
+      - logging-loki-audit-querier
+      - logging-loki-audit-query-frontend
+      - collector-with-cadf-to-loki-audit
+
+    common_project_list:
+      - openshift-logging
+      - openshift
+
+    common_service_nspace: openshift-logging
+    common_service_list:
+      - logging-loki-audit-distributor-grpc
+      - logging-loki-audit-distributor-http
+      - logging-loki-audit-gateway-http
+      - logging-loki-audit-gossip-ring
+      - logging-loki-audit-index-gateway-grpc
+      - logging-loki-audit-index-gateway-http
+      - logging-loki-audit-ingester-grpc
+      - logging-loki-audit-ingester-http
+      - logging-loki-audit-querier-grpc
+      - logging-loki-audit-querier-http
+      - logging-loki-audit-query-frontend-grpc
+      - logging-loki-audit-query-frontend-http
+
+  tasks:
+    - name: "Verify audit logging infrastructure components"
+      ansible.builtin.import_role:
+        name: common
+
+    - name: "Verify audit logging for OpenStack services"
+      ansible.builtin.import_role:
+        name: telemetry_audit_logging

--- a/ci/vars-audit-logging-fvt.yml
+++ b/ci/vars-audit-logging-fvt.yml
@@ -1,0 +1,13 @@
+---
+pre_tests_01_run_audit_logging_tests:
+  source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/run_audit_logging_tests.yml"
+  type: playbook
+  config_file: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/ansible.cfg"
+
+cifmw_run_tests: true
+cifmw_test_operator_tempest_include_list: |
+  ^tempest.*\[.*\bsmoke\b.*\]
+
+post_tests_99_collect_results:
+  source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/infrawatch/feature-verification-tests'].src_dir }}/ci/report_result.yml"
+  type: playbook

--- a/roles/telemetry_audit_logging/README.md
+++ b/roles/telemetry_audit_logging/README.md
@@ -1,0 +1,81 @@
+telemetry_audit_logging
+=======================
+
+Verify that OpenStack API audit events are emitted in CADF format and forwarded
+to the dedicated audit Loki stack. The scenarios follow the manual verification
+steps in
+[Manually enable audit logs](https://redhat.atlassian.net/wiki/spaces/CLOUDOPS/pages/389779771/Manually+enable+audit+logs).
+
+For each OpenStack service the role:
+
+1. Generates API activity with an ``openstack`` command
+2. Checks the service API pod logs for CADF audit notifications using ``oc logs``
+
+After all service checks, the role verifies Loki log separation using ``oc`` and
+``curl`` with an OpenShift bearer token, as documented in the forwarding section:
+
+* Default Loki (``logging-loki``) must **not** contain CADF audit events
+* Audit Loki (``logging-loki-audit``) **must** contain CADF audit events
+
+Requirements
+------------
+
+* OpenStack deployed with audit logging enabled
+* Audit Loki stack and ClusterLogForwarder configured in ``openshift-logging``
+* ``oc``, ``curl``, and ``openstack`` CLI access via ``openstackclient``
+
+Service verification steps
+--------------------------
+
++----------+---------------------------+-----------------------------------------------+
+| Service  | API activity              | Pod log check                                 |
++==========+===========================+===============================================+
+| Barbican | ``openstack secret list`` | ``grep barbican-api``                         |
+| Cinder   | ``openstack volume list`` | ``grep cinder-api``                           |
+| Glance   | ``openstack image list``  | ``grep glance-default``                       |
+| Keystone | ``openstack project list``| ``oc get pod -l service=keystone ...``        |
+| Neutron  | ``openstack network list``| ``grep neutron``                            |
+| Nova     | ``openstack server list`` | ``grep nova-api``                             |
++----------+---------------------------+-----------------------------------------------+
+
+Role Variables
+--------------
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| ``openstack_cmd`` | ``oc rsh openstackclient openstack`` | OpenStack CLI command |
+| ``audit_logging_namespace`` | ``openshift-logging`` | Namespace for Loki routes |
+| ``audit_logging_default_loki_route`` | ``logging-loki`` | Main Loki route name |
+| ``audit_logging_loki_route`` | ``logging-loki-audit`` | Audit Loki route name |
+| ``audit_logging_loki_tenant`` | ``application`` | Loki tenant in query URL |
+| ``audit_logging_loki_logql_query`` | ``{log_type="application"} \|= "..."`` | LogQL query for Loki checks |
+| ``audit_logging_services`` | see ``defaults/main.yml`` | List of service scenarios |
+
+Each service entry supports:
+
+* ``name`` - service identifier
+* ``trigger_args`` - arguments passed to ``openstack_cmd``
+* ``pod_pattern`` - substring used to locate the API pod
+* ``pod_label_selector`` - optional ``oc get pod -l`` selector (used for Keystone)
+
+Example Playbook
+----------------
+
+.. code-block:: yaml
+
+  - hosts: localhost
+    gather_facts: true
+    environment:
+      KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+      PATH: "{{ cifmw_path }}"
+    vars_files:
+      - vars/osp18_env.yml
+    tasks:
+      - name: "Run audit logging service tests"
+        ansible.builtin.import_role:
+          name: telemetry_audit_logging
+
+License
+-------
+
+Apache 2

--- a/roles/telemetry_audit_logging/defaults/main.yml
+++ b/roles/telemetry_audit_logging/defaults/main.yml
@@ -1,0 +1,42 @@
+---
+openstack_cmd: "oc rsh openstackclient openstack"
+audit_logging_openstack_namespace: openstack
+audit_logging_namespace: openshift-logging
+audit_logging_default_loki_route: logging-loki
+audit_logging_loki_route: logging-loki-audit
+audit_logging_loki_tenant: application
+audit_logging_cadf_event_pattern: "http://schemas.dmtf.org/cloud/audit/1.0/event"
+audit_logging_loki_logql_query: >-
+  {log_type="application"} |= "http://schemas.dmtf.org/cloud/audit/1.0/event"
+audit_logging_loki_query_retries: 6
+audit_logging_loki_query_delay: 10
+audit_logging_propagation_delay: 30
+
+# Verify steps from the manual audit logging guide for each service.
+# Disabling Barbican and Nova testing since those services still not enabled in CI
+
+audit_logging_services:
+#  - name: barbican
+#    trigger_args: "secret list"
+#    pod_pattern: barbican-api
+
+  - name: cinder
+    trigger_args: "volume list"
+    pod_pattern: cinder-api
+
+  - name: glance
+    trigger_args: "image list"
+    pod_pattern: glance-default
+
+  - name: keystone
+    trigger_args: "project list"
+    pod_label_selector: "service=keystone"
+    pod_pattern: keystone
+
+  - name: neutron
+    trigger_args: "network list"
+    pod_pattern: neutron
+
+#  - name: nova
+#    trigger_args: "server list"
+#    pod_pattern: nova-api

--- a/roles/telemetry_audit_logging/meta/main.yml
+++ b/roles/telemetry_audit_logging/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  author: Red Hat CloudOps team
+  description: Verify OpenStack API audit events are emitted and stored in Loki
+  company: Red Hat
+
+  license: Apache-2.0
+
+  min_ansible_version: "2.9"
+
+  galaxy_tags: []
+
+dependencies: []

--- a/roles/telemetry_audit_logging/tasks/main.yml
+++ b/roles/telemetry_audit_logging/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: "Setup Loki route URLs for audit log queries"
+  ansible.builtin.include_tasks: setup_loki_env.yml
+
+- name: "Verify audit logging for each OpenStack service"
+  ansible.builtin.include_tasks: verify_service_audit_logs.yml
+  loop: "{{ audit_logging_services }}"
+  loop_control:
+    loop_var: audit_service
+
+- name: "Verify audit events are separated into the audit Loki stack"
+  ansible.builtin.include_tasks: verify_loki_separation.yml

--- a/roles/telemetry_audit_logging/tasks/setup_loki_env.yml
+++ b/roles/telemetry_audit_logging/tasks/setup_loki_env.yml
@@ -1,0 +1,25 @@
+---
+- name: "Get default Loki route host"
+  ansible.builtin.command:
+    cmd: >
+      oc get route {{ audit_logging_default_loki_route }}
+      -n {{ audit_logging_namespace }}
+      -o jsonpath={.spec.host}
+  register: audit_default_loki_route
+  changed_when: false
+
+- name: "Get audit Loki route host"
+  ansible.builtin.command:
+    cmd: >
+      oc get route {{ audit_logging_loki_route }}
+      -n {{ audit_logging_namespace }}
+      -o jsonpath={.spec.host}
+  register: audit_loki_route
+  changed_when: false
+
+- name: "Set Loki query URLs"
+  ansible.builtin.set_fact:
+    audit_default_loki_query_url: >-
+      https://{{ audit_default_loki_route.stdout }}/api/logs/v1/{{ audit_logging_loki_tenant }}/loki/api/v1/query_range
+    audit_loki_query_url: >-
+      https://{{ audit_loki_route.stdout }}/api/logs/v1/{{ audit_logging_loki_tenant }}/loki/api/v1/query_range

--- a/roles/telemetry_audit_logging/tasks/verify_loki_separation.yml
+++ b/roles/telemetry_audit_logging/tasks/verify_loki_separation.yml
@@ -1,0 +1,52 @@
+---
+- name: "Wait for audit events to reach Loki"
+  ansible.builtin.pause:
+    seconds: "{{ audit_logging_propagation_delay }}"
+
+- name: "Query default Loki for CADF audit events"
+  ansible.builtin.shell:
+    cmd: |
+      curl -sk \
+        -H "Authorization: Bearer $(oc whoami --show-token)" \
+        "{{ audit_default_loki_query_url }}" \
+        --data-urlencode 'query={{ audit_logging_loki_logql_query }}'
+  register: audit_default_loki_query
+  changed_when: false
+  failed_when: audit_default_loki_query.rc != 0
+
+- name: "TEST Verify default Loki does not contain CADF audit events"
+  ansible.builtin.assert:
+    that:
+      - (audit_default_loki_query.stdout | from_json).data.result | length == 0
+    fail_msg: >-
+      FAILED: Default Loki ({{ audit_logging_default_loki_route }}) returned CADF audit events.
+      Audit events should only be forwarded to {{ audit_logging_loki_route }}.
+    success_msg: >-
+      SUCCESS: Default Loki does not contain CADF audit events.
+
+- name: "Query audit Loki for CADF audit events"
+  ansible.builtin.shell:
+    cmd: |
+      curl -sk \
+        -H "Authorization: Bearer $(oc whoami --show-token)" \
+        "{{ audit_loki_query_url }}" \
+        --data-urlencode 'query={{ audit_logging_loki_logql_query }}'
+  register: audit_loki_query
+  changed_when: false
+  until: >
+    audit_loki_query.rc == 0 and
+    (audit_loki_query.stdout | from_json).data.result | length > 0
+  retries: "{{ audit_logging_loki_query_retries }}"
+  delay: "{{ audit_logging_loki_query_delay }}"
+  failed_when: false
+
+- name: "TEST Verify audit Loki contains CADF audit events"
+  ansible.builtin.assert:
+    that:
+      - audit_loki_query.rc == 0
+      - (audit_loki_query.stdout | from_json).data.result | length > 0
+    fail_msg: >-
+      FAILED: Audit Loki ({{ audit_logging_loki_route }}) did not return CADF audit events.
+      LogQL: {{ audit_logging_loki_logql_query }}
+    success_msg: >-
+      SUCCESS: Audit Loki contains CADF audit events.

--- a/roles/telemetry_audit_logging/tasks/verify_service_audit_logs.yml
+++ b/roles/telemetry_audit_logging/tasks/verify_service_audit_logs.yml
@@ -1,0 +1,15 @@
+---
+- name: "Generate API activity for {{ audit_service.name }}"
+  ansible.builtin.command:
+    cmd: "{{ openstack_cmd }} {{ audit_service.trigger_args }}"
+  register: audit_trigger
+  changed_when: false
+  failed_when: audit_trigger.rc != 0
+
+- name: "TEST Check {{ audit_service.name }} API pod logs for CADF audit events"
+  ansible.builtin.shell:
+    cmd: |
+      oc logs $(oc get pod{% if audit_service.pod_label_selector is defined %} -l {{ audit_service.pod_label_selector }}{% endif %} -n {{ audit_logging_openstack_namespace }} -o name | grep {{ audit_service.pod_pattern }} | head -1) | grep "{{ audit_logging_cadf_event_pattern }}"
+  register: audit_pod_logs
+  changed_when: false
+  failed_when: audit_pod_logs.rc != 0


### PR DESCRIPTION
A new role for telemetry audit logging

The telemetry_audit_logging role validates and tests the RHOSO audit logging feature. It performs audit logging configuration validation, generates  relevant API activity and checks for relevant data in logs.

Verify that OpenStack API audit events are emitted in CADF format and forwarded
to the dedicated audit Loki stack. The scenarios follow the manual verification steps in 

[Manually enable audit logs](https://redhat.atlassian.net/wiki/spaces/CLOUDOPS/pages/389779771/Manually+enable+audit+logs).