### PR TITLE
[telemetry_chargeback] -FVT Allow artifacts_zuul_dir to be passed to role at run time

### DIFF
--- a/roles/telemetry_chargeback/defaults/main.yml
+++ b/roles/telemetry_chargeback/defaults/main.yml
@@ -13,6 +13,10 @@ cert_dir: "{{ cifmw_basedir }}/ck-certs"
 local_cert_dir: "{{ cifmw_basedir }}/flush_certs"
 remote_cert_dir: "osp-certs"
 
+# Output file paths
+cloudkitty_data_file: "{{ artifacts_dir_zuul }}/{{ scenario_name }}{{ cloudkitty_synth_data_suffix }}"
+cloudkitty_synth_totals_file: "{{ artifacts_dir_zuul }}/{{ scenario_name }}{{ cloudkitty_synth_totals_metrics_suffix }}"
+
 # Cloudkitty certificates and secrets
 cert_secret_name: "cert-cloudkitty-client-internal"
 client_secret: "secret/cloudkitty-lokistack-gateway-client-http"

--- a/roles/telemetry_chargeback/vars/main.yml
+++ b/roles/telemetry_chargeback/vars/main.yml
@@ -4,6 +4,7 @@ cloudkitty_scenario_dir: "{{ role_path }}/files"
 cloudkitty_synth_script: "{{ role_path }}/files/gen_synth_loki_data.py"
 cloudkitty_data_template: "{{ role_path }}/templates/loki_data_templ.j2"
 cloudkitty_summary_script: "{{ role_path }}/files/gen_db_summary.py"
+cloudkitty_test_file: "{{ cloudkitty_scenario_dir }}/{{ scenario_name }}.yml"
 
 # File naming conventions (internal standardization)
 cloudkitty_synth_data_suffix: "-synth_data.json"
@@ -11,13 +12,6 @@ cloudkitty_loki_data_suffix: "-loki_data.json"
 cloudkitty_synth_totals_metrics_suffix: "-synth_metrics_summary.yml"
 cloudkitty_loki_totals_metrics_suffix: "-loki_metrics_summary.yml"
 cloudkitty_loki_totals_suffix: "-rating.yml"
-
-cloudkitty_data_file: >-
-  {{ artifacts_dir_zuul }}/{{ scenario_name }}{{ cloudkitty_synth_data_suffix }}
-cloudkitty_synth_totals_file: >-
-  {{ artifacts_dir_zuul }}/{{ scenario_name }}{{ cloudkitty_synth_totals_metrics_suffix }}
-cloudkitty_test_file: >-
-  {{ cloudkitty_scenario_dir }}/{{ scenario_name }}.yml
 
 # initialize var
 previous_end_time: ""


### PR DESCRIPTION
Move the output file paths to default dir so that they can be easily overwritten