### PR TITLE
[telemetry_chargeback] FVT - Fixed synthetic data rating calculations to be consistent with cloudkitty 

### DIFF
--- a/roles/telemetry_chargeback/files/gen_db_summary.py
+++ b/roles/telemetry_chargeback/files/gen_db_summary.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Parse Loki JSON (or text) into [timestep, log_entry] pairs, then emit a YAML
-summary: time, data_log, and rate (per-type Σ(qty×price) and total Rating).
+summary: time, data_log, and rate (per-type Σ(price) and total Rating).
 
 Same CLI as gen_synth_loki_metrics_totals.py (-j, -o, --debug).
 """
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 import sys
 from collections import Counter, defaultdict
 from pathlib import Path
@@ -18,7 +17,7 @@ from typing import Any, Optional
 import yaml
 
 REQUIRED_KEYS = frozenset(
-    {"start", "end", "type", "unit", "qty", "price", "groupby"}
+    {"start", "end", "type", "unit", "qty", "unit_cost", "price", "groupby"}
 )
 
 
@@ -100,45 +99,12 @@ def extract_and_sort(json_path: Path) -> list[tuple[str, str]]:
     return pairs
 
 
-def _apply_mutate(qty: float, mutate: str) -> float:
-    """
-    Apply mutate transformation to qty value.
-
-    Args:
-        qty: The quantity value to transform.
-        mutate: The mutation type (NONE, CEIL, FLOOR, NUMBOOL, NOTNUMBOOL).
-
-    Returns:
-        The transformed quantity.
-    """
-    mutate_upper = mutate.upper() if isinstance(mutate, str) else "NONE"
-
-    if mutate_upper == "CEIL":
-        return math.ceil(qty)
-    elif mutate_upper == "FLOOR":
-        return math.floor(qty)
-    elif mutate_upper == "NUMBOOL":
-        # If qty near 0, set it at 0. Else, set it to 1.
-        return 0.0 if abs(qty) < 1e-9 else 1.0
-    elif mutate_upper == "NOTNUMBOOL":
-        # If qty near 0, set it to 1. Else, set it to 0.
-        return 1.0 if abs(qty) < 1e-9 else 0.0
-    else:  # NONE or any unrecognized value
-        return qty
-
-
 def _parse_numeric(value: Any, default: float = 0) -> float:
     """
-    Parse a numeric value, supporting fractions like '1/1048576'.
-
-    This function handles the 'factor' field in scenario YAML files which uses
-    fraction notation (e.g., '1/1048576' to convert bytes to MiB) to match
-    CloudKitty/chargeback documentation standards. Without this parser,
-    fraction strings would cause ValueError when passed to float(), silently
-    dropping metrics from the output summary.
+    Parse a numeric value from JSON entry fields.
 
     Args:
-        value: The value to parse (can be number, string, or fraction string)
+        value: The value to parse (can be number or string)
         default: Default value if parsing fails
 
     Returns:
@@ -146,30 +112,13 @@ def _parse_numeric(value: Any, default: float = 0) -> float:
     """
     if value is None:
         return default
-
-    # If it's already a number, convert directly
     if isinstance(value, (int, float)):
         return float(value)
-
-    # If it's a string, check for fraction notation (e.g., "1/1048576")
     if isinstance(value, str):
-        value = value.strip()
-        if '/' in value:
-            try:
-                parts = value.split('/')
-                if len(parts) == 2:
-                    numerator = float(parts[0].strip())
-                    denominator = float(parts[1].strip())
-                    if denominator != 0:
-                        return numerator / denominator
-            except (ValueError, ZeroDivisionError):
-                pass
-        # Try direct conversion
         try:
-            return float(value)
+            return float(value.strip())
         except ValueError:
             pass
-
     return default
 
 
@@ -191,28 +140,14 @@ def aggregate_rates_by_type(
         try:
             qty = _parse_numeric(entry.get("qty"), 0)
             price = _parse_numeric(entry.get("price"), 0)
-            factor = _parse_numeric(entry.get("factor"), 1)
-            offset = _parse_numeric(entry.get("offset"), 0)
-            mutate = entry.get("mutate", "NONE")
         except (TypeError, ValueError):
             continue
 
-        # Track raw qty sum (before any transformation)
         qty_sums[mtype] += qty
 
-        # CRITICAL FIX: Follow CloudKitty methodology - conversion BEFORE
-        # mutation. Per CloudKitty docs, "Quantity mutation is done AFTER
-        # conversion"
-        # https://docs.openstack.org/cloudkitty/2025.2/admin/configuration/collector.html
-
-        # Step 1: Apply factor and offset (unit conversion)
-        qty_converted = qty * factor + offset
-
-        # Step 2: Apply mutate transformation (happens AFTER conversion)
-        qty_mutated = _apply_mutate(qty_converted, mutate)
-
-        # Step 3: Calculate rate
-        rate_sums[mtype] += qty_mutated * price
+        # Price is already the computed cost for this entry
+        # (unit_cost * qty_mutated), matching CK dataframe Price field
+        rate_sums[mtype] += price
 
     by_types = {
         k: {"Rate": round(v, 4)} for k, v in sorted(rate_sums.items())

--- a/roles/telemetry_chargeback/files/gen_synth_loki_data.py
+++ b/roles/telemetry_chargeback/files/gen_synth_loki_data.py
@@ -10,6 +10,32 @@ from typing import Dict, Any, List, Union
 from jinja2 import Environment
 
 
+def _apply_mutate(qty: float, mutate) -> float:
+    """
+    Apply mutate transformation to qty value.
+
+    Args:
+        qty: The quantity value to transform.
+        mutate: The mutation type (NONE, CEIL, FLOOR, NUMBOOL, NOTNUMBOOL).
+
+    Returns:
+        The transformed quantity.
+    """
+    import math
+    mutate_upper = mutate.upper() if isinstance(mutate, str) else "NONE"
+
+    if mutate_upper == "CEIL":
+        return math.ceil(qty)
+    elif mutate_upper == "FLOOR":
+        return math.floor(qty)
+    elif mutate_upper == "NUMBOOL":
+        return 0.0 if abs(qty) < 1e-9 else 1.0
+    elif mutate_upper == "NOTNUMBOOL":
+        return 1.0 if abs(qty) < 1e-9 else 0.0
+    else:
+        return qty
+
+
 def _get_value_for_step(
     values: List[Union[int, float]],
     step_idx: int,
@@ -109,7 +135,6 @@ def generate_loki_data(
     end_time: datetime,
     time_step_seconds: int,
     config: Dict[str, Any],
-    scenario_name: str,
     reverse_timestamps: bool = True,
 ):
     """
@@ -122,7 +147,6 @@ def generate_loki_data(
         end_time (datetime): The end time for data generation.
         time_step_seconds (int): The duration of each log entry in seconds.
         config (Dict[str, Any]): Configuration dictionary loaded from file.
-        scenario_name (str): Name of the test scenario for Loki labeling.
         reverse_timestamps (bool): If True, sort timestamps in descending order
             (newest first, oldest last). If False, sort in ascending order
             (oldest first, newest last). Default is True (descending).
@@ -227,23 +251,24 @@ def generate_loki_data(
                 f"groupby must be a dictionary for {type_key!r}"
             )
 
-        # Ensure qty and price are lists for step-based distribution
+        # Ensure qty and unit_cost are lists for step-based distribution
         qty_val = log_type_config["qty"]
-        price_val = log_type_config["price"]
+        unit_cost_val = log_type_config["unit_cost"]
         qty_list = qty_val if isinstance(qty_val, list) else [qty_val]
-        price_list = price_val if isinstance(price_val, list) else [price_val]
+        unit_cost_list = (
+            unit_cost_val if isinstance(unit_cost_val, list)
+            else [unit_cost_val]
+        )
 
         log_types[type_key] = {
             "type": type_key,
             "unit": log_type_config["unit"],
             "description": log_type_config.get("description"),
             "qty": qty_list,
-            "price": price_list,
+            "unit_cost": unit_cost_list,
             "groupby": groupby.copy(),
             "metadata": log_type_config.get("metadata", {}),
-            "mutate": log_type_config.get("mutate"),
-            "factor": log_type_config.get("factor"),
-            "offset": log_type_config.get("offset")
+            "mutate": log_type_config.get("mutate")
         }
 
     # --- Step 3: Load template and render ---
@@ -310,26 +335,32 @@ def generate_loki_data(
             log_type_with_dates = log_type_data.copy()
             log_type_with_dates["groupby"] = log_type_data["groupby"].copy()
             log_type_with_dates["groupby"].update(date_fields)
-            # Select qty and price based on step index distribution
-            log_type_with_dates["qty"] = _get_value_for_step(
+            # Select qty and unit_cost based on step index distribution
+            qty = _get_value_for_step(
                 log_type_data["qty"], idx, num_steps
             )
-            log_type_with_dates["price"] = _get_value_for_step(
-                log_type_data["price"], idx, num_steps
+            unit_cost = _get_value_for_step(
+                log_type_data["unit_cost"], idx, num_steps
             )
+
+            # Calculate price: apply mutate to qty, then multiply by
+            # unit_cost (matches CK dataframe Price field)
+            mutate = log_type_data.get("mutate")
+            qty_mutated = _apply_mutate(qty, mutate)
+            price = unit_cost * qty_mutated
+
+            log_type_with_dates["qty"] = qty
+            log_type_with_dates["unit_cost"] = unit_cost
+            log_type_with_dates["price"] = price
             log_types_with_dates[log_type_name] = log_type_with_dates
 
         log_types_list.append(log_types_with_dates)
 
-    # Get loki_stream configuration and add scenario
+    # Get loki_stream configuration
     loki_stream = config.get("loki_stream", {})
     if not loki_stream:
         logger.warning("No loki_stream configuration found, using defaults")
         loki_stream = {"service": "cloudkitty"}
-
-    # Add scenario name to loki_stream labels
-    loki_stream["scenario"] = scenario_name
-    logger.info(f"Adding scenario label: {scenario_name}")
 
     # Build template context with generic log type information
     template_context = {
@@ -459,13 +490,14 @@ def main():
         logger.critical(f"Failed to load config: {e}")
         sys.exit(1)
 
-    # Derive scenario name from test file path
-    scenario_name = args.test.stem
-    logger.info(f"Derived scenario name from test file: {scenario_name}")
-
     # Get generation parameters from config
     generation_config = config.get("generation", {})
-    days = generation_config.get("days", 30)
+    days_raw = generation_config.get("days", 30)
+    if isinstance(days_raw, str) and '/' in days_raw:
+        num, den = days_raw.split('/')
+        days = float(num.strip()) / float(den.strip())
+    else:
+        days = float(days_raw)
     step_seconds = generation_config.get("step_seconds", 300)
 
     # Define the time range for data generation
@@ -484,7 +516,7 @@ def main():
             )
             sys.exit(1)
     else:
-        end_time_utc = datetime.now(timezone.utc) - timedelta(hours=2)
+        end_time_utc = datetime.now(timezone.utc)
         logger.debug(
             f"Using current UTC time minus 2 hours as end_time: "
             f"{end_time_utc}"
@@ -507,7 +539,6 @@ def main():
             end_time=end_time_utc,
             time_step_seconds=step_seconds,
             config=config,
-            scenario_name=scenario_name,
             reverse_timestamps=args.reverse,
         )
     except FileNotFoundError:

--- a/roles/telemetry_chargeback/files/test_dyn_basic.yml
+++ b/roles/telemetry_chargeback/files/test_dyn_basic.yml
@@ -1,38 +1,23 @@
 ---
 # Scenario configuration for synthetic Loki log data generation
+# Scenario configuration for CloudKitty chargeback testing
 
 # Time range configuration
 generation:
-  days: 1
-  step_seconds: 14400
+  days: 1/24
+  step_seconds: 300
 
 # Log type definitions (single "type" = identifier and value pushed to output)
 log_types:
-  - type: ceilometer_image_size
-    description: "Size of ceilometer image"
-    unit: MiB
-    qty:
-      - 10000
-    price:
-      - 0.10
-    groupby:
-      resource: tenant-01
-      user: null
-      project: null
-    metadata:
-      container_format: bare
-      disk_format: qcow2
-
   - type: ceilometer_image_test
     description: "Size of ceilometer test"
-    unit: B
-#   factor: 1
+    unit: MiB
     qty:
-      - 10000
-    price:
-      - 0.10
+      - 909
+    unit_cost:
+      - 0.00009
     groupby:
-      resource: tenant-01
+      resource: cloudkitty
       user: null
       project: null
     metadata:
@@ -45,10 +30,10 @@ log_types:
     alt_name: instance
     qty:
       - 1
-    price:
+    unit_cost:
       - 5.00
     groupby:
-      resource: tenant-02
+      resource: cloudkitty
       user: null
       project: null
       flavor_name: null
@@ -60,39 +45,26 @@ log_types:
     unit: ip
     qty:
       - 5
-    price:
+    unit_cost:
       - 1.00
     groupby:
-      resource: tenant-01
+      resource: cloudkitty
       user: null
       project: null
     metadata:
       state: null
     mutate: NUMBOOL
 
-  - type: ceilometer_disk_ephemeral_size
-    description: "Max at each timestep"
-    unit: GiB
-    qty:
-      - 0.0
-    price:
-      - 0.0
-    groupby:
-      resource: tenant-01
-      user: null
-      project: null
-    metadata:
-      type: null
-
   - type: ceilometer_disk_root_size
     description: null
     unit: GiB
     qty:
-      - 10000
-    price:
-      - 0.10
+      - 3000
+    # $0.023/GiB/month → per 300s: 0.023 / 8640
+    unit_cost:
+      - 0.000003
     groupby:
-      resource: tenant-02
+      resource: cloudkitty
       user: null
       project: null
     metadata:
@@ -100,13 +72,13 @@ log_types:
 
   - type: ceilometer_network_outgoing_bytes
     description: null
-    unit: B
+    unit: MiB
     qty:
       - 0.0
-    price:
-      - 0.0
+    unit_cost:
+      - 0.00009
     groupby:
-      resource: tenant-01
+      resource: cloudkitty
       user: null
       project: null
     metadata:
@@ -114,13 +86,13 @@ log_types:
 
   - type: ceilometer_network_incoming_bytes
     description: null
-    unit: B
+    unit: MiB
     qty:
-      - 0.0
-    price:
-      - 0.0
+      - 1000
+    unit_cost:
+      - 0.00009
     groupby:
-      resource: tenant-02
+      resource: cloudkitty
       user: null
       project: null
     metadata:
@@ -131,7 +103,7 @@ required_fields:
   - type
   - unit
   - qty
-  - price
+  - unit_cost
   - groupby
 
 # Date field names to add to groupby

--- a/roles/telemetry_chargeback/files/test_static.yml
+++ b/roles/telemetry_chargeback/files/test_static.yml
@@ -1,9 +1,10 @@
 # Scenario configuration for synthetic Loki log data generation
+# Scenario configuration for CloudKitty chargeback testing
 
 # Time range configuration
 generation:
-  days: 1
-  step_seconds: 7200
+  days: 1/24
+  step_seconds: 300
 
 # Log type definitions
 log_types:
@@ -11,10 +12,10 @@ log_types:
     type: ceilometer_image_size
     unit: MiB
     description: null
-    qty: 20.6
-    price: 0.02
+    qty: 2324
+    unit_cost: 0.00009
     groupby:
-      resource: tenant-01
+      resource: cloudkitty
       project: null
       user: null
     metadata:
@@ -26,9 +27,9 @@ log_types:
     unit: instance
     description: null
     qty: 1.0
-    price: 0.3
+    unit_cost: 0.3
     groupby:
-      resource: tenant-02
+      resource: cloudkitty
       project: null
       user: null
     metadata:
@@ -41,7 +42,7 @@ required_fields:
   - type
   - unit
   - qty
-  - price
+  - unit_cost
   - groupby
   - metadata
 

--- a/roles/telemetry_chargeback/templates/loki_data_templ.j2
+++ b/roles/telemetry_chargeback/templates/loki_data_templ.j2
@@ -1,4 +1,4 @@
-{"streams": [{ "stream": { "service": "{{ loki_stream.service }}", "scenario": "{{ loki_stream.scenario }}" }, "values": [
+{"streams": [{ "stream": { "service": "{{ loki_stream.service }}" }, "values": [
 {%- for item in log_data %}
 {%- set outer_idx = loop.index0 %}
 {%- set is_last_outer = loop.last %}
@@ -11,12 +11,11 @@
     "unit": entry_data.unit,
     "description": entry_data.description,
     "qty": entry_data.qty,
+    "unit_cost": entry_data.unit_cost,
     "price": entry_data.price,
     "groupby": entry_data.groupby,
     "metadata": entry_data.metadata,
-    "mutate": entry_data.get("mutate"),
-    "factor": entry_data.get("factor"),
-    "offset": entry_data.get("offset")
+    "mutate": entry_data.get("mutate")
 } -%}
 [
 "{{ item.nanoseconds }}",


### PR DESCRIPTION
gen_synth_loki_data.py:
- Compute price at generation time: price = unit_cost * qty_mutated.
- Add _apply_mutate() for NUMBOOL/CEIL/FLOOR transforms.
- Removed 2 hour offset

gen_db_summary.py 
- Simplify to sum "price" directly (matching CK method)
- Use price to generate rating  

Test Scenarios files:
- Update test scenarios: 1-hour window, 300s steps, realistic costs.
- Remove factor/offset from all files
- Remove "price" from test scenario


Authored-by: @ayefimov-1
AI Assisted by: Claude
