### PR TITLE
[telemetry_chargeback] [FVT] Add Loki ring convergence check and update defaults

### DIFF
--- a/roles/telemetry_chargeback/defaults/main.yml
+++ b/roles/telemetry_chargeback/defaults/main.yml
@@ -26,11 +26,10 @@ cloudkitty_namespace: "openstack"
 openstackpod: "openstackclient"
 
 # Time window settings
-lookback: 6
-limit: 50
+limit: 1500
 
 # List of test scenario files to run
-cloudkitty_test_scenarios: ["test_static" , "test_dyn_basic"]
+cloudkitty_test_scenarios: ["test_static", "test_dyn_basic"]
 
 # Output file paths
 # ALL variables using {{ artifacts_dir_zuul }} should be defined in defaults/main.yml

--- a/roles/telemetry_chargeback/tasks/setup_loki_env.yml
+++ b/roles/telemetry_chargeback/tasks/setup_loki_env.yml
@@ -57,3 +57,25 @@
     cmd: |
       oc extract {{ ca_configmap }} --to={{ local_cert_dir }} --confirm -n {{ cloudkitty_namespace }}
   changed_when: true
+
+# Wait for Loki gossip ring to converge before ingesting data.
+# When the ring hasn't converged, ingesters accept writes but are
+# invisible to queriers, causing queries to return empty results.
+- name: "Wait for Loki ring to converge"
+  ansible.builtin.uri:
+    url: "https://cloudkitty-lokistack-ingester-http.{{ cloudkitty_namespace }}.svc:3100/ring"
+    method: GET
+    client_cert: "{{ cert_dir }}/tls.crt"
+    client_key: "{{ cert_dir }}/tls.key"
+    ca_path: "{{ cert_dir }}/ca.crt"
+    validate_certs: false
+    return_content: true
+  register: ring_response
+  until:
+    - ring_response.status == 200
+    - "'JOINING' not in ring_response.content"
+    - "'PENDING' not in ring_response.content"
+    - "'LEAVING' not in ring_response.content"
+  retries: 20
+  delay: 15
+  changed_when: false

--- a/roles/telemetry_chargeback/tasks/setup_loki_env.yml
+++ b/roles/telemetry_chargeback/tasks/setup_loki_env.yml
@@ -61,21 +61,33 @@
 # Wait for Loki gossip ring to converge before ingesting data.
 # When the ring hasn't converged, ingesters accept writes but are
 # invisible to queriers, causing queries to return empty results.
+# Uses oc exec because the ingester service DNS is only resolvable
+# from inside the cluster.
+- name: "Create cert directory in OpenStack Client pod"
+  ansible.builtin.command:
+    cmd: "oc exec -n {{ cloudkitty_namespace }} {{ openstackpod }} -- mkdir -p {{ remote_cert_dir }}"
+  changed_when: false
+
+- name: "Copy certificates to OpenStack Client pod"
+  ansible.builtin.command:
+    cmd: "oc cp {{ local_cert_dir }}/. {{ cloudkitty_namespace }}/{{ openstackpod }}:{{ remote_cert_dir }}/"
+  changed_when: false
+
 - name: "Wait for Loki ring to converge"
-  ansible.builtin.uri:
-    url: "https://cloudkitty-lokistack-ingester-http.{{ cloudkitty_namespace }}.svc:3100/ring"
-    method: GET
-    client_cert: "{{ cert_dir }}/tls.crt"
-    client_key: "{{ cert_dir }}/tls.key"
-    ca_path: "{{ cert_dir }}/ca.crt"
-    validate_certs: false
-    return_content: true
+  ansible.builtin.command:
+    cmd: >
+      oc exec -n {{ cloudkitty_namespace }} {{ openstackpod }} --
+      curl -s
+      --cert {{ remote_cert_dir }}/tls.crt
+      --key {{ remote_cert_dir }}/tls.key
+      --cacert {{ remote_cert_dir }}/service-ca.crt
+      https://cloudkitty-lokistack-ingester-http.{{ cloudkitty_namespace }}.svc:3100/ring
   register: ring_response
   until:
-    - ring_response.status == 200
-    - "'JOINING' not in ring_response.content"
-    - "'PENDING' not in ring_response.content"
-    - "'LEAVING' not in ring_response.content"
+    - ring_response.rc == 0
+    - "'JOINING' not in ring_response.stdout"
+    - "'PENDING' not in ring_response.stdout"
+    - "'LEAVING' not in ring_response.stdout"
   retries: 20
   delay: 15
   changed_when: false


### PR DESCRIPTION
Fix for Loki returning empty query results caused by ring partitioning 
- Wait for the Loki gossip ring to converge before ingesting synthetic data
- Preventing empty query results caused by ring partitioning. 
- remove lookback, increase limit to 1500

Authored-by: @ayefimov-1
AI Assisted by: Claude
