### PR TITLE
[telemetry_chargeback] - FVT Fix main.yml variable reference and add 2-hour offset comment

### DIFF
--- a/roles/telemetry_chargeback/files/gen_synth_loki_data.py
+++ b/roles/telemetry_chargeback/files/gen_synth_loki_data.py
@@ -484,6 +484,8 @@ def main():
             )
             sys.exit(1)
     else:
+        # Use 2-hour offset to prevent synthetic data from overlapping with
+        # real-time CloudKitty data collection during test execution
         end_time_utc = datetime.now(timezone.utc) - timedelta(hours=2)
         logger.debug(
             f"Using current UTC time minus 2 hours as end_time: "

--- a/roles/telemetry_chargeback/tasks/main.yml
+++ b/roles/telemetry_chargeback/tasks/main.yml
@@ -14,7 +14,7 @@
       loop: "{{ cloudkitty_test_scenarios | reverse | list }}"
       loop_control:
         loop_var: scenario_name
-      when: scenarios_to_run | length > 0
+      when: cloudkitty_test_scenarios | length > 0
 
   rescue:
     - name: "Log failure"


### PR DESCRIPTION
- Fix when condition to reference cloudkitty_test_scenarios
- Add comment explaining 2-hour offset prevents data corruption
- Update gen_synth_loki_data.py to use 2-hour offset from current time