### PR TITLE
Avoid blocking QDR interrupt loops on oc delete --wait

### DIFF
--- a/roles/test_alerts/tasks/test_creating_a_standard_alert_route_in_alert_manager.yml
+++ b/roles/test_alerts/tasks/test_creating_a_standard_alert_route_in_alert_manager.yml
@@ -81,7 +81,10 @@
     - name: "RHELOSP-148697 Interrupt metrics flow by preventing the QDR from running"
       ansible.builtin.shell:
         cmd: |
-          for i in {1..30}; do oc delete po -l application=default-interconnect; sleep 1; done
+          for i in {1..30}; do
+            oc delete po -l application=default-interconnect --wait=false --ignore-not-found
+            sleep 5
+          done
       changed_when: false
 
     - name: "RHELOSP-148698 Verify that the alert is active in Alertmanager"

--- a/roles/test_snmp_traps/tasks/main.yml
+++ b/roles/test_snmp_traps/tasks/main.yml
@@ -83,7 +83,10 @@
     - name: "RHELOSP-144966 Interrupt metrics flow by preventing the QDR from running"
       ansible.builtin.shell:
         cmd: |
-          for i in {1..60}; do oc delete po -l application=default-interconnect; sleep 1; done
+          for i in {1..60}; do
+            oc delete po -l application=default-interconnect --wait=false --ignore-not-found
+            sleep 5
+          done
       changed_when: false
 
     - name: Verify the alert is firing in Alertmanager

--- a/roles/test_verify_email/tasks/main.yml
+++ b/roles/test_verify_email/tasks/main.yml
@@ -51,7 +51,10 @@
     - name: "RHELOSP-176044 Interrupt metrics flow by preventing the QDR from running"
       ansible.builtin.shell:
         cmd: |
-          for i in {1..60}; do oc delete po -l application=default-interconnect; sleep 1; done
+          for i in {1..60}; do
+            oc delete po -l application=default-interconnect --wait=false --ignore-not-found
+            sleep 5
+          done
       changed_when: false
 
     - name: "RHELOSP-176045 Check for alertmanager logs"


### PR DESCRIPTION
Use --wait=false so interconnect pod churn does not stall for minutes per iteration under load, which was hanging stf_functional_tests.

Assisted-by: Cursor <cursoragent@cursor.com>