### PR TITLE
[telemetry_chargeback] FVT - enable summary rating validation after each test scenario 

### DIFF
--- a/roles/telemetry_chargeback/README.md
+++ b/roles/telemetry_chargeback/README.md
@@ -39,13 +39,8 @@ Role Variables
 |----------|---------------|-------------|
 | `openstack_cmd` | `"openstack"` | OpenStack CLI command |
 | `cloudkitty_debug` | `false` | Enable debug mode for CloudKitty operations |
-
-#### Directory Paths
-
-| Variable | Default Value | Description |
-|----------|---------------|-------------|
+| `cloudkitty_debug_dir` | `"{{ (cloudkitty_debug \| bool) \| ternary(cloudkitty_artifacts_dir + '/debug_ck_db', '') }}"` | Directory for debug output (auto-set based on debug flag) |
 | `cloudkitty_artifacts_dir` | `"{{ cifmw_basedir }}/artifacts"` | Directory for generated artifacts and test output |
-| `cloudkitty_logs_dir` | `"{{ cifmw_basedir }}/logs"` | Directory for log files |
 | `cert_dir` | `"{{ cifmw_basedir }}/ck-certs"` | Directory for CloudKitty client certificates |
 | `local_cert_dir` | `"{{ cifmw_basedir }}/flush_certs"` | Local directory for flush certificates |
 | `remote_cert_dir` | `"osp-certs"` | Remote directory inside OpenStack pod for certificates |
@@ -65,88 +60,12 @@ Role Variables
 | `cert_secret_name` | `"cert-cloudkitty-client-internal"` | OpenShift secret name for client certificates |
 | `client_secret` | `"secret/cloudkitty-lokistack-gateway-client-http"` | Secret for flush client certificates |
 | `ca_configmap` | `"cm/cloudkitty-lokistack-ca-bundle"` | ConfigMap for CA bundle |
-
-#### Loki Query Settings
-
-| Variable | Default Value | Description |
-|----------|---------------|-------------|
-| `logql_query` | `"{{ loki_query \| default('{service=\"cloudkitty\"}') }}"` | LogQL query for Loki (overridable via `loki_query`) |
-| `limit` | `1500` | Maximum entries for Loki query results |
-
-#### Test Scenarios
-
-| Variable | Default Value | Description |
-|----------|---------------|-------------|
-| `cloudkitty_test_scenarios` | `["test_static", "test_dyn_basic"]` | List of test scenario names (without `.yml` extension) |
-
-### Internal Variables (vars/main.yml)
-
-#### Paths to Scripts and Templates
-
-| Variable | Value | Description |
-|----------|-------|-------------|
-| `cloudkitty_scenario_dir` | `"{{ role_path }}/files"` | Directory containing scenario YAML files |
-| `cloudkitty_synth_script` | `"{{ role_path }}/files/gen_synth_loki_data.py"` | Path to synthetic data generation script |
-| `cloudkitty_data_template` | `"{{ role_path }}/templates/loki_data_templ.j2"` | Path to Jinja2 template for log generation |
-| `cloudkitty_summary_script` | `"{{ role_path }}/files/gen_db_summary.py"` | Path to metrics summary script |
-
-#### File Naming Suffixes (Internal Standardization)
-
-| Variable | Value | Description |
-|----------|-------|-------------|
-| `cloudkitty_synth_data_suffix` | `"-synth_data.json"` | Suffix for synthetic data JSON files |
-| `cloudkitty_loki_data_suffix` | `"-loki_data.json"` | Suffix for Loki query result files |
-| `cloudkitty_synth_totals_metrics_suffix` | `"-synth_metrics_summary.yml"` | Suffix for synthetic metrics summary |
-| `cloudkitty_loki_totals_metrics_suffix` | `"-loki_metrics_summary.yml"` | Suffix for Loki metrics summary |
-
-#### Test Scenario File Path
-
-| Variable | Value | Description |
-|----------|-------|-------------|
-| `cloudkitty_test_file` | `"{{ cloudkitty_scenario_dir }}/{{ scenario_name }}.yml"` | Full path to scenario YAML file |
-
-#### Loop Control Variable
-
-| Variable | Scope | Description |
-|----------|-------|-------------|
-| `scenario_name` | Per-iteration | Current scenario name being processed (set by loop) |
-
-### Output Variables (defaults/main.yml - Artifact Paths)
-
-#### Scenario-Specific Output Files
-
-These are derived from `cloudkitty_artifacts_dir` and the internal file suffixes:
-
-| Variable | Value | Description |
-|----------|-------|-------------|
-| `cloudkitty_data_file` | `"{{ cloudkitty_artifacts_dir }}/{{ scenario_name }}{{ cloudkitty_synth_data_suffix }}"` | Synthetic JSON data file per scenario |
-| `cloudkitty_loki_data_file` | `"{{ cloudkitty_artifacts_dir }}/{{ scenario_name }}{{ cloudkitty_loki_data_suffix }}"` | Loki query result file per scenario |
-| `cloudkitty_synth_totals_file` | `"{{ cloudkitty_artifacts_dir }}/{{ scenario_name }}{{ cloudkitty_synth_totals_metrics_suffix }}"` | Synthetic metrics summary per scenario |
-| `cloudkitty_loki_summary_metrics_file` | `"{{ cloudkitty_artifacts_dir }}/{{ scenario_name }}{{ cloudkitty_loki_totals_metrics_suffix }}"` | Loki metrics summary per scenario |
-
-#### Total Rate Output Files
-
-| Variable | Value | Description |
-|----------|-------|-------------|
-| `cloudkitty_loki_totals_file` | `"{{ cloudkitty_artifacts_dir }}/loki_total_rate{{ cloudkitty_loki_data_suffix }}"` | Monthly Loki data aggregation |
-| `cloudkitty_rate_summary_file` | `"{{ cloudkitty_artifacts_dir }}/loki_total_rate{{ cloudkitty_loki_totals_metrics_suffix }}"` | Monthly rating summary |
-| `cloudkitty_rating_by_type_file` | `"{{ cloudkitty_artifacts_dir }}/loki_total_rate.yml"` | CloudKitty rating breakdown by type |
-
-### Runtime Variables (Computed During Execution)
-
-These variables are set during task execution and used for scenario chaining and data flow:
-
-| Variable | Set By | Used By | Description |
-|----------|--------|---------|-------------|
-| `previous_end_time` | `gen_synth_loki_data.yml` | `gen_synth_loki_data.py` | End time of previous scenario, used as start time for current scenario |
-| `cloudkitty_data_file_output` | `gen_synth_loki_data.yml` (register) | `gen_synth_loki_data.yml` | Output from synthetic data generation script |
-| `synth_data_rates` | `gen_synth_loki_data.yml` (from YAML) | `retrieve_loki_data.yml` | Parsed synthetic metrics summary (timestamp and log counts) |
-| `scenario_logql_query` | `retrieve_loki_data.yml` | `retrieve_loki_data.yml` | LogQL query specific to current scenario |
-| `loki_base_url` | `setup_loki_env.yml` | All Loki tasks | Base URL for Loki API |
-| `loki_push_url` | `setup_loki_env.yml` | `ingest_loki_data.yml` | Loki push/ingest API endpoint |
-| `loki_query_url` | `setup_loki_env.yml` | `retrieve_loki_data.yml` | Loki query API endpoint |
-| `ingester_flush_url` | `setup_loki_env.yml` | `flush_loki_data.yml` | Loki ingester flush endpoint |
-| `loki_response` | `retrieve_loki_data.yml` (register) | `retrieve_loki_data.yml` | HTTP response from Loki query |
+| `logql_query` | `"{{ loki_query \| default('{service=\"cloudkitty\"}') }}"` | LogQL query for Loki (overridable via `loki_query` variable) |
+| `cloudkitty_namespace` | `"openstack"` | Kubernetes namespace where CloudKitty is deployed |
+| `openstackpod` | `"openstackclient"` | OpenStack client pod name for exec/cp operations |
+| `lookback` | `6` | Days to look back for Loki query time range |
+| `limit` | `1500` | Limit for Loki query results |
+| `cloudkitty_test_scenarios` | `["test_static", "test_dyn_basic"]` | List of test scenario files to run|
 
 How It Works
 ------------

--- a/roles/telemetry_chargeback/README.md
+++ b/roles/telemetry_chargeback/README.md
@@ -33,24 +33,120 @@ Role Variables
 
 ### User-Configurable Variables (defaults/main.yml)
 
+#### OpenStack CLI & Debug Settings
+
 | Variable | Default Value | Description |
 |----------|---------------|-------------|
-| `openstack_cmd` | `"openstack"` | OpenStack CLI command (customize if not in PATH) |
+| `openstack_cmd` | `"openstack"` | OpenStack CLI command |
 | `cloudkitty_debug` | `false` | Enable debug mode for CloudKitty operations |
-| `cloudkitty_debug_dir` | `"{{ (cloudkitty_debug \| bool) \| ternary(cloudkitty_artifacts_dir + '/debug_ck_db', '') }}"` | Directory for debug output (auto-set based on debug flag) |
+
+#### Directory Paths
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
 | `cloudkitty_artifacts_dir` | `"{{ cifmw_basedir }}/artifacts"` | Directory for generated artifacts and test output |
+| `cloudkitty_logs_dir` | `"{{ cifmw_basedir }}/logs"` | Directory for log files |
 | `cert_dir` | `"{{ cifmw_basedir }}/ck-certs"` | Directory for CloudKitty client certificates |
-| `local_cert_dir` | `"{{ cifmw_basedir }}/flush_certs"` | Local directory for flush certificates (cleaned up after run) |
+| `local_cert_dir` | `"{{ cifmw_basedir }}/flush_certs"` | Local directory for flush certificates |
 | `remote_cert_dir` | `"osp-certs"` | Remote directory inside OpenStack pod for certificates |
+| `cloudkitty_debug_dir` | `"{{ (cloudkitty_debug \| bool) \| ternary(cloudkitty_artifacts_dir + '/debug_ck_db', '') }}"` | Directory for debug output (auto-set based on debug flag) |
+
+#### OpenShift/Kubernetes Settings
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+| `cloudkitty_namespace` | `"openstack"` | Kubernetes namespace where CloudKitty is deployed |
+| `openstackpod` | `"openstackclient"` | OpenStack client pod name |
+
+#### CloudKitty Certificates & Secrets
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
 | `cert_secret_name` | `"cert-cloudkitty-client-internal"` | OpenShift secret name for client certificates |
 | `client_secret` | `"secret/cloudkitty-lokistack-gateway-client-http"` | Secret for flush client certificates |
 | `ca_configmap` | `"cm/cloudkitty-lokistack-ca-bundle"` | ConfigMap for CA bundle |
-| `logql_query` | `"{{ loki_query \| default('{service=\"cloudkitty\"}') }}"` | LogQL query for Loki (overridable via `loki_query` variable) |
-| `cloudkitty_namespace` | `"openstack"` | Kubernetes namespace where CloudKitty is deployed |
-| `openstackpod` | `"openstackclient"` | OpenStack client pod name for exec/cp operations |
-| `lookback` | `6` | Days to look back for Loki query time range |
-| `limit` | `1500` | Limit for Loki query results |
-| `cloudkitty_test_scenarios` | `["test_static", "test_dyn_basic"]` | List of test scenario files to run|
+
+#### Loki Query Settings
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+| `logql_query` | `"{{ loki_query \| default('{service=\"cloudkitty\"}') }}"` | LogQL query for Loki (overridable via `loki_query`) |
+| `limit` | `1500` | Maximum entries for Loki query results |
+
+#### Test Scenarios
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+| `cloudkitty_test_scenarios` | `["test_static", "test_dyn_basic"]` | List of test scenario names (without `.yml` extension) |
+
+### Internal Variables (vars/main.yml)
+
+#### Paths to Scripts and Templates
+
+| Variable | Value | Description |
+|----------|-------|-------------|
+| `cloudkitty_scenario_dir` | `"{{ role_path }}/files"` | Directory containing scenario YAML files |
+| `cloudkitty_synth_script` | `"{{ role_path }}/files/gen_synth_loki_data.py"` | Path to synthetic data generation script |
+| `cloudkitty_data_template` | `"{{ role_path }}/templates/loki_data_templ.j2"` | Path to Jinja2 template for log generation |
+| `cloudkitty_summary_script` | `"{{ role_path }}/files/gen_db_summary.py"` | Path to metrics summary script |
+
+#### File Naming Suffixes (Internal Standardization)
+
+| Variable | Value | Description |
+|----------|-------|-------------|
+| `cloudkitty_synth_data_suffix` | `"-synth_data.json"` | Suffix for synthetic data JSON files |
+| `cloudkitty_loki_data_suffix` | `"-loki_data.json"` | Suffix for Loki query result files |
+| `cloudkitty_synth_totals_metrics_suffix` | `"-synth_metrics_summary.yml"` | Suffix for synthetic metrics summary |
+| `cloudkitty_loki_totals_metrics_suffix` | `"-loki_metrics_summary.yml"` | Suffix for Loki metrics summary |
+
+#### Test Scenario File Path
+
+| Variable | Value | Description |
+|----------|-------|-------------|
+| `cloudkitty_test_file` | `"{{ cloudkitty_scenario_dir }}/{{ scenario_name }}.yml"` | Full path to scenario YAML file |
+
+#### Loop Control Variable
+
+| Variable | Scope | Description |
+|----------|-------|-------------|
+| `scenario_name` | Per-iteration | Current scenario name being processed (set by loop) |
+
+### Output Variables (defaults/main.yml - Artifact Paths)
+
+#### Scenario-Specific Output Files
+
+These are derived from `cloudkitty_artifacts_dir` and the internal file suffixes:
+
+| Variable | Value | Description |
+|----------|-------|-------------|
+| `cloudkitty_data_file` | `"{{ cloudkitty_artifacts_dir }}/{{ scenario_name }}{{ cloudkitty_synth_data_suffix }}"` | Synthetic JSON data file per scenario |
+| `cloudkitty_loki_data_file` | `"{{ cloudkitty_artifacts_dir }}/{{ scenario_name }}{{ cloudkitty_loki_data_suffix }}"` | Loki query result file per scenario |
+| `cloudkitty_synth_totals_file` | `"{{ cloudkitty_artifacts_dir }}/{{ scenario_name }}{{ cloudkitty_synth_totals_metrics_suffix }}"` | Synthetic metrics summary per scenario |
+| `cloudkitty_loki_summary_metrics_file` | `"{{ cloudkitty_artifacts_dir }}/{{ scenario_name }}{{ cloudkitty_loki_totals_metrics_suffix }}"` | Loki metrics summary per scenario |
+
+#### Total Rate Output Files
+
+| Variable | Value | Description |
+|----------|-------|-------------|
+| `cloudkitty_loki_totals_file` | `"{{ cloudkitty_artifacts_dir }}/loki_total_rate{{ cloudkitty_loki_data_suffix }}"` | Monthly Loki data aggregation |
+| `cloudkitty_rate_summary_file` | `"{{ cloudkitty_artifacts_dir }}/loki_total_rate{{ cloudkitty_loki_totals_metrics_suffix }}"` | Monthly rating summary |
+| `cloudkitty_rating_by_type_file` | `"{{ cloudkitty_artifacts_dir }}/loki_total_rate.yml"` | CloudKitty rating breakdown by type |
+
+### Runtime Variables (Computed During Execution)
+
+These variables are set during task execution and used for scenario chaining and data flow:
+
+| Variable | Set By | Used By | Description |
+|----------|--------|---------|-------------|
+| `previous_end_time` | `gen_synth_loki_data.yml` | `gen_synth_loki_data.py` | End time of previous scenario, used as start time for current scenario |
+| `cloudkitty_data_file_output` | `gen_synth_loki_data.yml` (register) | `gen_synth_loki_data.yml` | Output from synthetic data generation script |
+| `synth_data_rates` | `gen_synth_loki_data.yml` (from YAML) | `retrieve_loki_data.yml` | Parsed synthetic metrics summary (timestamp and log counts) |
+| `scenario_logql_query` | `retrieve_loki_data.yml` | `retrieve_loki_data.yml` | LogQL query specific to current scenario |
+| `loki_base_url` | `setup_loki_env.yml` | All Loki tasks | Base URL for Loki API |
+| `loki_push_url` | `setup_loki_env.yml` | `ingest_loki_data.yml` | Loki push/ingest API endpoint |
+| `loki_query_url` | `setup_loki_env.yml` | `retrieve_loki_data.yml` | Loki query API endpoint |
+| `ingester_flush_url` | `setup_loki_env.yml` | `flush_loki_data.yml` | Loki ingester flush endpoint |
+| `loki_response` | `retrieve_loki_data.yml` (register) | `retrieve_loki_data.yml` | HTTP response from Loki query |
 
 How It Works
 ------------
@@ -306,6 +402,7 @@ Example Playbook
       vars:
         cloudkitty_test_scenarios:
           - "test_static.yml"
+          - "test_dyn_basic.yml"
 ```
 
 **Run custom scenarios via extra-vars:**

--- a/roles/telemetry_chargeback/defaults/main.yml
+++ b/roles/telemetry_chargeback/defaults/main.yml
@@ -38,7 +38,7 @@ cloudkitty_synth_totals_file: "{{ cloudkitty_artifacts_dir }}/{{ scenario_name }
 cloudkitty_loki_summary_metrics_file: "{{ cloudkitty_artifacts_dir }}/{{ scenario_name }}{{ cloudkitty_loki_totals_metrics_suffix }}"
 
 # Total rate output files (loki_total_rate prefix)
-cloudkitty_loki_totals_file: "{{ cloudkitty_artifacts_dir }}/loki_totals{{ cloudkitty_loki_data_suffix }}"
-cloudkitty_loki_rating_summary_file: "{{ cloudkitty_artifacts_dir }}/loki_total_rate{{ cloudkitty_loki_totals_metrics_suffix }}"
-cloudkitty_loki_rating_by_type_file: "{{ cloudkitty_artifacts_dir }}/loki_rating_by_type.yml"
-cloudkitty_loki_rating_dataframes_file: "{{ cloudkitty_artifacts_dir }}/loki_rating_dataframes.yml"
+cloudkitty_loki_totals_file: "{{ cloudkitty_artifacts_dir }}/loki_totals_{{ scenario_name }}{{ cloudkitty_loki_data_suffix }}"
+cloudkitty_loki_rating_summary_file: "{{ cloudkitty_artifacts_dir }}/loki_summary_rating_{{ scenario_name }}{{ cloudkitty_loki_totals_metrics_suffix }}"
+cloudkitty_loki_rating_by_type_file: "{{ cloudkitty_artifacts_dir }}/loki_rating_by_type_{{ scenario_name }}.yml"
+cloudkitty_loki_rating_dataframes_file: "{{ cloudkitty_artifacts_dir }}/loki_rating_dataframes_{{ scenario_name }}.yml"

--- a/roles/telemetry_chargeback/tasks/loki_total_rate.yml
+++ b/roles/telemetry_chargeback/tasks/loki_total_rate.yml
@@ -1,7 +1,7 @@
 ---
 # This task retrieves ALL CloudKitty logs for the current month from Loki
-# and generates a comprehensive rate summary. It runs at the end of the role
-# to capture all data ingested during test scenarios.
+# and generates a comprehensive rate summary. It runs after each scenario
+# to validate the accumulated rating, enabling early failure detection.
 
 - name: "Calculate current month time range (start to now)"
   ansible.builtin.set_fact:
@@ -30,7 +30,7 @@
       - "Limit: {{ limit }}"
 
 # Query Loki for all data in current month
-- name: "TEST Retrieve Logs from Loki via API loki total_rate"
+- name: "TEST Retrieve Logs from Loki via API for all scenarios in current month"
   block:
     - name: "Query Loki API for current month data"
       ansible.builtin.uri:
@@ -56,7 +56,7 @@
         dest: "{{ cloudkitty_loki_totals_file }}"
         mode: '0644'
 
-    - name: "TEST Generate chargeback stats from Loki total_rate data"
+    - name: "TEST Generate chargeback stats from Loki total_rate data for all scenarios"
       ansible.builtin.command:
         cmd: >
           python3 "{{ cloudkitty_summary_script }}"
@@ -78,7 +78,7 @@
           - "Message: {{ loki_response.msg | default('Request failed') }}"
 
 # Display accumulated total rate for job
-- name: "Display accumulated total rate for job"
+- name: "Display accumulated rating for job"
   ansible.builtin.debug:
     msg: "Total rate for entire job across all scenarios: {{ total_rate_job }}"
 
@@ -145,7 +145,7 @@
     rating_diff: "{{ (synth_rating | float - ck_rating | float) | abs | round(4) }}"
     rating_tolerance: "{{ (synth_rating | float + ck_rating | float) * rating_tolerance_pct / 2 | round(4) }}"
 
-- name: "TEST Assert synthetic rating matches CloudKitty rating"
+- name: "TEST Assert synthetic rating matches CloudKitty rating for all scenarios"
   ansible.builtin.assert:
     that:
       - rating_diff | float < rating_tolerance | float

--- a/roles/telemetry_chargeback/tasks/main.yml
+++ b/roles/telemetry_chargeback/tasks/main.yml
@@ -16,9 +16,6 @@
         loop_var: scenario_name
       when: cloudkitty_test_scenarios | length > 0
 
-    - name: "Get total rate from Loki for all scenarios"
-      ansible.builtin.include_tasks: "loki_total_rate.yml"
-
   rescue:
     - name: "Log failure"
       ansible.builtin.fail:

--- a/roles/telemetry_chargeback/tasks/run_test_scenarios.yml
+++ b/roles/telemetry_chargeback/tasks/run_test_scenarios.yml
@@ -10,3 +10,6 @@
 
 - name: "Update job scenario statistics for {{ scenario_name }}"
   ansible.builtin.include_tasks: "job_scenario_stats.yml"
+
+- name: "Get total rate from Loki {{ scenario_name }}"
+  ansible.builtin.include_tasks: "loki_total_rate.yml"  

--- a/roles/telemetry_chargeback/vars/main.yml
+++ b/roles/telemetry_chargeback/vars/main.yml
@@ -18,6 +18,6 @@ cloudkitty_test_file: "{{ cloudkitty_scenario_dir }}/{{ scenario_name }}.yml"
 # initialize var
 previous_scenario_end_time: ""
 total_rate_job: 0
-rating_tolerance_pct: 0.005
+rating_tolerance_pct: 0.001
 job_earliest_start_time: 0
 job_latest_end_time: 0


### PR DESCRIPTION
 - Per-scenario rating validation: Move loki_total_rate.yml into the per-scenario loop so CloudKitty's rating is compared against the accumulated synthetic rating after each scenario
  - Task naming: Add {{ scenario_name }} to task names in loki_total_rate.yml for clearer CI log output
  - Tighten rating diff tolerance 

Authored-by: @ayefimov-1
AI Assisted by: Claude