### PR TITLE
Reduce futile retries in autoscaling tests on failure

### DIFF
--- a/roles/telemetry_autoscaling/tasks/creating_stack.yml
+++ b/roles/telemetry_autoscaling/tasks/creating_stack.yml
@@ -46,6 +46,9 @@
     {{ openstack_cmd }} stack show {{ stack_name }};
   register: result
   until: '"CREATE_COMPLETE" in result.stdout'
+  failed_when: >-
+    "CREATE_FAILED" in result.stdout or
+    "DELETE" in result.stdout
   timeout: 30
   retries: 20
 
@@ -60,7 +63,9 @@
   timeout: 30
   retries: 20
   until: '"CREATE_COMPLETE" in result.stdout'
-  #failed_when: '"CREATE_COMPLETE" not in result.stdout'
+  failed_when: >-
+    "CREATE_FAILED" in result.stdout or
+    "DELETE" in result.stdout
 
 - name: |
     TEST Verify ceilometer cpu metrics exist

--- a/roles/telemetry_autoscaling/tasks/test_autoscaling.yml
+++ b/roles/telemetry_autoscaling/tasks/test_autoscaling.yml
@@ -108,14 +108,19 @@
       delay: 5
       register: instance_count2
       until: instance_count2.stdout_lines | length == 3
-      
+
     - name: Ensure Scaling Up instance result is set
       ansible.builtin.set_fact:
-        scaling_up_success: "{{ instance_count2.stdout_lines | length == 3 }}"
+        scaling_up_success: true
 
     - name: Debug scaling_up_success
       ansible.builtin.debug:
         var: scaling_up_success
+
+  rescue:
+    - name: "TEST Scaling Up instance - marking scale-up as failed"
+      ansible.builtin.set_fact:
+        scaling_up_success: false
 
 
 - name: Stop the busy process
@@ -123,10 +128,15 @@
     sshpass -p gocubsgo ssh cirros@{{ item | trim }} "sudo killall yes"
   register: kill_busy_process
   with_items: "{{ vnf_instance_ip.stdout_lines }}"
+  ignore_errors: true
 
 - name:  TEST Scaling down instance
-  when: scaling_up_success | bool
   block:
+    - name: "TEST Scaling down instance"
+      ansible.builtin.fail:
+        msg: "Scale-down tests cannot run: scale-up did not succeed"
+      when: not (scaling_up_success | default(false) | bool)
+
     - name: |
         TEST Verify cpu low alarm has been triggered
       ansible.builtin.shell: |


### PR DESCRIPTION
When a prerequisite fails (e.g. Heat stack enters CREATE_FAILED), downstream retry loops would spin to exhaustion before failing, wasting significant CI time. This change adds early-exit conditions and proper failure propagation to avoid unnecessary retries.

Changes:
- creating_stack.yml: Add failed_when to the stack and resource CREATE_COMPLETE retry loops to detect terminal states (CREATE_FAILED, DELETE*) and fail immediately
- test_autoscaling.yml: Add rescue block to scale-up so scaling_up_success is always set; mark scale-down as failed (not skipped) when scale-up fails; make "Stop the busy process" best-effort with ignore_errors

Estimated CI time savings on failure:
- Stack creation retry loops: ~20 min (2x 20 retries * 30s timeout)
- Scale-down retry loops:    ~21 min (260 retries * 5s delay)
- Total:                     ~41 min saved per failed run


Because these savings are on FAILED jobs, this PR is is validated in https://github.com/infrawatch/feature-verification-tests/pull/429 (baseline) and https://github.com/infrawatch/feature-verification-tests/pull/430 (with this change) 

Assisted-By: Claude Opus 4.6